### PR TITLE
New Alarm Wizard: Back to previous steps

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -197,7 +197,11 @@ class App extends Component {
               <div
                 className={`${styles.FooterLeft} ${gridStyles.colLg6} ${gridStyles.colMd6} ${gridStyles.colSm6} ${gridStyles.colXs6}`}
               >
-                <a href="https://www.lizard.net/handleidingen/log_in_instructies_lizard_6.01.pdf">
+                <a
+                  href="https://www.lizard.net/handleidingen/log_in_instructies_lizard_6.01.pdf"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   <FormattedMessage
                     id="index.documentation"
                     defaultMessage="Documentation"

--- a/src/alarms/notifications/NewNotification.js
+++ b/src/alarms/notifications/NewNotification.js
@@ -87,6 +87,7 @@ class NewNotification extends Component {
     this.removeFromGroupAndTemplate = this.removeFromGroupAndTemplate.bind(
       this
     );
+    this.goBackToStep = this.goBackToStep.bind(this);
   }
   componentDidMount() {
     const { bootstrap } = this.props;
@@ -212,7 +213,7 @@ class NewNotification extends Component {
       loading: true
     });
 
-    console.log("spatial bounds:", raster.spatial_bounds);
+    // console.log("spatial bounds:", raster.spatial_bounds);
 
     const { west, east, north, south } = raster.spatial_bounds;
 
@@ -249,7 +250,9 @@ class NewNotification extends Component {
     });
   }
   loadTimeseriesData() {
+    
     // EXAMPLE ENDPOINT URLS:
+
     // /api/v3/raster-aggregates/?agg=average&geom=POINT+(4.6307373046875+52.00855538139683)&rasters=730d667&srs=EPSG:4326&start=2017-09-27T00:12:01&stop=2017-09-29T03:12:01&window=3600000
     // /api/v3/raster-aggregates/?agg=curve&geom=POINT+(5.463488101959228+51.45954224745201)&rasters=fc72da4&srs=EPSG:4326&start=2008-01-01T12:00:00&stop=2012-12-31T18:00:00&window=2635200000
 
@@ -293,6 +296,14 @@ class NewNotification extends Component {
       messages: messages
     });
   }
+  goBackToStep(toStep) {
+    const {step} = this.state;
+    if (toStep < step) {
+      this.setState({
+        step: toStep
+      });
+    }
+  }
   render() {
     const position = [52.1858, 5.2677];
 
@@ -324,7 +335,7 @@ class NewNotification extends Component {
               <div id="steps" style={{ margin: "20px 0 0 20px" }}>
                 <div className={styles.Step} id="Step">
                   <div className="media">
-                    <StepIndicator indicator="1" active={step === 1} />
+                    <StepIndicator indicator="1" active={step === 1} handleClick={() => this.goBackToStep(1)} />
                     <div
                       style={{
                         width: "calc(100% - 90px)",
@@ -387,7 +398,7 @@ class NewNotification extends Component {
 
                 <div className={styles.Step} id="Step">
                   <div className="media">
-                    <StepIndicator indicator="2" active={step === 2} />
+                    <StepIndicator indicator="2" active={step === 2} handleClick={() => this.goBackToStep(2)} />
                     <div
                       style={{
                         width: "calc(100% - 90px)",
@@ -446,7 +457,7 @@ class NewNotification extends Component {
 
                 <div className={styles.Step} id="Step">
                   <div className="media">
-                    <StepIndicator indicator="3" active={step === 3} />
+                    <StepIndicator indicator="3" active={step === 3} handleClick={() => this.goBackToStep(3)} />
                     <div
                       style={{
                         marginLeft: 90
@@ -568,7 +579,7 @@ class NewNotification extends Component {
 
                 <div className={styles.Step} id="Step">
                   <div className="media">
-                    <StepIndicator indicator="4" active={step === 4} />
+                    <StepIndicator indicator="4" active={step === 4} handleClick={() => this.goBackToStep(4)} />
                     <div
                       style={{
                         marginLeft: 90
@@ -645,7 +656,7 @@ class NewNotification extends Component {
                                   <button
                                     type="button"
                                     className={`${buttonStyles.Button} ${buttonStyles.Small} ${buttonStyles.Link} ${gridStyles.FloatRight}`}
-                                    onClick={() => console.log("remove")}
+                                    onClick={() => console.log("Remove still has to be implemented...")}
                                   >
                                     <FormattedMessage
                                       id="notifications_app.newnotification_remove"

--- a/src/components/StepIndicator.css
+++ b/src/components/StepIndicator.css
@@ -13,6 +13,7 @@
 }
 .Inactive {
   background-color: #b9b9b9;
+  cursor: pointer;
 }
 .Active {
   background-color: #00cdab;

--- a/src/components/StepIndicator.js
+++ b/src/components/StepIndicator.js
@@ -3,9 +3,10 @@ import styles from "./StepIndicator.css";
 
 class StepIndicator extends Component {
   render() {
-    const { indicator, active } = this.props;
+    const { indicator, active, handleClick } = this.props;
     return (
       <div
+        onClick={handleClick}
         className={`${styles.StepIndicator} ${active
           ? styles.Active
           : styles.Inactive}`}


### PR DESCRIPTION
If the user is at step 2 and wants to go back to step 1, he/she can now click on previous step indicators ('1' in this case) and the UI will go back to that step.

![screen shot 2018-05-30 at 07 30 28](https://user-images.githubusercontent.com/7193/40700796-6589de36-63db-11e8-8d43-1d8242766d47.jpg)

Only works for going backwards by design. 
Going forward (without checking for values) will break the app, because it would allow null values to be POSTed to the API.

