### PR TITLE
[DONE] make pagination work with search

### DIFF
--- a/src/components/SearchBox.js
+++ b/src/components/SearchBox.js
@@ -6,17 +6,10 @@ import formStyles from "../styles/Forms.css";
 import clearInputStyles from "./ClearInputButton.css";
 
 class SearchBox extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      localSearchTerms: ""
-    };
-  }
-
   handleEnter(event) {
     if (event.keyCode === 13) {
       // 13 is keycode 'enter' (works only when current input validates)
-      this.props.handleSearch(this.state.localSearchTerms);
+      this.props.handleSearch(this.props.searchTerms);
     }
   }
 
@@ -43,7 +36,7 @@ class SearchBox extends Component {
           <input
             type="text"
             placeholder={searchTerm}
-            value={this.state.localSearchTerms}
+            value={this.props.searchTerms}
             className={formStyles.FormControl}
             style={{
               // make sure input field has same height as search button
@@ -53,7 +46,7 @@ class SearchBox extends Component {
               borderBottomRightRadius: "0px"
             }}
             onChange={e => {
-              this.setState({ localSearchTerms: e.target.value });
+              this.props.setSearchTerms(e.target.value);
             }}
             onKeyUp={e => this.handleEnter(e)}
           />
@@ -62,7 +55,7 @@ class SearchBox extends Component {
             className={`${clearInputStyles.ClearInput} material-icons`}
             style={{ right: "6px" }}
             onClick={() => {
-              this.setState({ localSearchTerms: "" });
+              this.props.setSearchTerms(this.props.searchTerms);
               this.props.handleSearch("");
             }}
           >
@@ -72,7 +65,7 @@ class SearchBox extends Component {
         <button
           type="button"
           className={`${buttonStyles.Button} ${buttonStyles.Success}`}
-          onClick={e => handleSearch(this.state.localSearchTerms)}
+          onClick={e => handleSearch(this.props.searchTerms)}
         >
           <FormattedMessage id="search" defaultMessage="Search" />
           <Ink />

--- a/src/data_management/rasters/Raster.js
+++ b/src/data_management/rasters/Raster.js
@@ -21,7 +21,8 @@ class Raster extends Component {
       isFetching: true,
       rasters: [],
       total: 0,
-      page: 1
+      page: 1,
+      searchTerms: ""
     };
     this.handleNewRasterClick = this.handleNewRasterClick.bind(this);
     this.loadRastersOnPage = this.loadRastersOnPage.bind(this);
@@ -131,6 +132,8 @@ class Raster extends Component {
               handleSearch={searchContains =>
                 this.loadRastersOnPage(this.state.page, searchContains)
               }
+              searchTerms={this.state.searchTerms}
+              setSearchTerms={searchTerms => this.setState({ searchTerms })}
             />
           </div>
           <div
@@ -216,7 +219,9 @@ class Raster extends Component {
             } ${gridStyles.colXs8}`}
           >
             <PaginationBar
-              loadRastersOnPage={this.loadRastersOnPage}
+              loadRastersOnPage={page =>
+                this.loadRastersOnPage(page, this.state.searchTerms)
+              }
               page={page}
               pages={Math.ceil(total / 10)}
             />


### PR DESCRIPTION
Pagination did previously not work in combination with search.
When requesting the second page it would request the second page without the search query.

This is fixed by moving the searchTerms state up from searchComponent to Raster list component and passing the searchTerms to the request new page function.

