### PR TITLE
[Done] Make it possible to also select a nested asset.

### DIFF
--- a/src/alarms/notifications/NewNotification.js
+++ b/src/alarms/notifications/NewNotification.js
@@ -324,7 +324,7 @@ class NewNotification extends Component {
     });
   }
   validateTimeseriesNestedAsset(obj) {
-    return obj.name || obj.code;
+    return obj.code || obj.name;
   }
   handleResetTimeseriesNestedAsset() {
     this.setState({

--- a/src/alarms/notifications/NewNotification.js
+++ b/src/alarms/notifications/NewNotification.js
@@ -76,6 +76,9 @@ class NewNotification extends Component {
       selectedTimeseriesAssetFromSearchEndpoint: {},
       selectedTimeseriesAssetFromAssetEndpoint: {},
 
+      timeseriesNestedAssetsFromAsset: [],
+      selectedTimeseriesNestedAsset: {},
+
       selectedTimeseriesUuid: "22450124-519f-4ca1-9ab4-0ae0648081f0"
     };
     this.handleInputNotificationName = this.handleInputNotificationName.bind(
@@ -98,6 +101,15 @@ class NewNotification extends Component {
     this.handleSetTimeseriesAsset = this.handleSetTimeseriesAsset.bind(this);
     this.validateTimeseriesAsset = this.validateTimeseriesAsset.bind(this);
     this.handleResetTimeseriesAsset = this.handleResetTimeseriesAsset.bind(
+      this
+    );
+    this.handleSetTimeseriesNestedAsset = this.handleSetTimeseriesNestedAsset.bind(
+      this
+    );
+    this.validateTimeseriesNestedAsset = this.validateTimeseriesNestedAsset.bind(
+      this
+    );
+    this.handleResetTimeseriesNestedAsset = this.handleResetTimeseriesNestedAsset.bind(
       this
     );
     this.handleSetRaster = this.handleSetRaster.bind(this);
@@ -273,6 +285,7 @@ class NewNotification extends Component {
     }
   }
   async handleSetTimeseriesAsset(assetObj) {
+    this.handleResetTimeseriesAsset();
     this.setState({
       selectedTimeseriesAssetFromSearchEndpoint: assetObj
     });
@@ -300,8 +313,27 @@ class NewNotification extends Component {
   }
   handleResetTimeseriesAsset() {
     this.setState({
+      // Reset asset(s)
       foundTimeseriesAssetsSearchEndpoint: [],
-      selectedTimeseriesAssetFromSearchEndpoint: {}
+      selectedTimeseriesAssetFromSearchEndpoint: {},
+      selectedTimeseriesAssetFromAssetEndpoint: {},
+      // Reset nested asset(s)
+      timeseriesNestedAssetsFromAsset: [],
+      selectedTimeseriesNestedAsset: {}
+    });
+  }
+  async handleSetTimeseriesNestedAsset(nestedAssetObj) {
+    this.setState({
+      selectedTimeseriesNestedAsset: nestedAssetObj
+    });
+  }
+  validateTimeseriesNestedAsset(obj) {
+    return obj.name || obj.code;
+  }
+  handleResetTimeseriesNestedAsset() {
+    this.setState({
+      timeseriesNestedAssetsFromAsset: [],
+      selectedTimeseriesNestedAsset: {}
     });
   }
   handleSetAsset(view) {
@@ -771,6 +803,49 @@ class NewNotification extends Component {
                                 validate={this.validateTimeseriesAsset}
                                 resetModelValue={
                                   this.handleResetTimeseriesAsset
+                                }
+                                readonly={false}
+                                noneValue={undefined}
+                              />{" "}
+                              <br />
+                              <SelectBoxSearch
+                                choices={
+                                  this.state.timeseriesNestedAssetsFromAsset
+                                }
+                                choice={
+                                  this.state.selectedTimeseriesNestedAsset
+                                }
+                                transformChoiceToDisplayValue={e =>
+                                  (e && e.name) || (e && e.code) || ""}
+                                isFetching={false}
+                                updateModelValue={
+                                  this.handleSetTimeseriesNestedAsset
+                                }
+                                onKeyUp={e => {
+                                  let asset = this.state
+                                    .selectedTimeseriesAssetFromAssetEndpoint;
+                                  if (asset.filters) {
+                                    this.setState({
+                                      timeseriesNestedAssetsFromAsset:
+                                        asset.filters
+                                    });
+                                  } else if (asset.pumps) {
+                                    this.setState({
+                                      timeseriesNestedAssetsFromAsset:
+                                        asset.pumps
+                                    });
+                                  }
+                                }}
+                                inputId={
+                                  "notifications_app.select_timeserie_via_nested_asset" +
+                                  "_input"
+                                }
+                                placeholder={
+                                  "Click to select timeseries nested asset"
+                                }
+                                validate={this.validateTimeseriesNestedAsset}
+                                resetModelValue={
+                                  this.handleResetTimeseriesNestedAsset
                                 }
                                 readonly={false}
                                 noneValue={undefined}

--- a/src/alarms/notifications/NewNotification.js
+++ b/src/alarms/notifications/NewNotification.js
@@ -312,7 +312,6 @@ class NewNotification extends Component {
   }
   handleResetTimeseriesAsset() {
     this.setState({
-      // Reset asset(s)
       foundTimeseriesAssetsSearchEndpoint: [],
       selectedTimeseriesAssetFromSearchEndpoint: {},
       selectedTimeseriesAssetFromAssetEndpoint: {}

--- a/src/alarms/notifications/NewNotification.js
+++ b/src/alarms/notifications/NewNotification.js
@@ -68,8 +68,8 @@ class NewNotification extends Component {
       thresholds: [],
 
       sourceType: {
-        display: "Timeseries",
-        description: "Put an alarm on timeseries data"
+        display: "Rasters",
+        description: "Put an alarm on raster data"
       },
 
       foundTimeseriesAssetsSearchEndpoint: [],

--- a/src/alarms/notifications/NewNotification.js
+++ b/src/alarms/notifications/NewNotification.js
@@ -315,10 +315,9 @@ class NewNotification extends Component {
       // Reset asset(s)
       foundTimeseriesAssetsSearchEndpoint: [],
       selectedTimeseriesAssetFromSearchEndpoint: {},
-      selectedTimeseriesAssetFromAssetEndpoint: {},
-      // Reset nested asset(s)
-      selectedTimeseriesNestedAsset: {}
+      selectedTimeseriesAssetFromAssetEndpoint: {}
     });
+    this.handleResetTimeseriesNestedAsset();
   }
   async handleSetTimeseriesNestedAsset(nestedAssetObj) {
     this.setState({

--- a/src/alarms/notifications/NewNotification.js
+++ b/src/alarms/notifications/NewNotification.js
@@ -68,15 +68,14 @@ class NewNotification extends Component {
       thresholds: [],
 
       sourceType: {
-        display: "Rasters",
-        description: "Put an alarm on raster data"
+        display: "Timeseries",
+        description: "Put an alarm on timeseries data"
       },
 
       foundTimeseriesAssetsSearchEndpoint: [],
       selectedTimeseriesAssetFromSearchEndpoint: {},
       selectedTimeseriesAssetFromAssetEndpoint: {},
 
-      timeseriesNestedAssetsFromAsset: [],
       selectedTimeseriesNestedAsset: {},
 
       selectedTimeseriesUuid: "22450124-519f-4ca1-9ab4-0ae0648081f0"
@@ -318,7 +317,6 @@ class NewNotification extends Component {
       selectedTimeseriesAssetFromSearchEndpoint: {},
       selectedTimeseriesAssetFromAssetEndpoint: {},
       // Reset nested asset(s)
-      timeseriesNestedAssetsFromAsset: [],
       selectedTimeseriesNestedAsset: {}
     });
   }
@@ -332,7 +330,6 @@ class NewNotification extends Component {
   }
   handleResetTimeseriesNestedAsset() {
     this.setState({
-      timeseriesNestedAssetsFromAsset: [],
       selectedTimeseriesNestedAsset: {}
     });
   }
@@ -810,32 +807,24 @@ class NewNotification extends Component {
                               <br />
                               <SelectBoxSearch
                                 choices={
-                                  this.state.timeseriesNestedAssetsFromAsset
+                                  this.state
+                                    .selectedTimeseriesAssetFromAssetEndpoint
+                                    .pumps ||
+                                  this.state
+                                    .selectedTimeseriesAssetFromAssetEndpoint
+                                    .filters ||
+                                  []
                                 }
                                 choice={
                                   this.state.selectedTimeseriesNestedAsset
                                 }
                                 transformChoiceToDisplayValue={e =>
-                                  (e && e.name) || (e && e.code) || ""}
+                                  (e && e.code) || (e && e.name) || ""}
                                 isFetching={false}
                                 updateModelValue={
                                   this.handleSetTimeseriesNestedAsset
                                 }
-                                onKeyUp={e => {
-                                  let asset = this.state
-                                    .selectedTimeseriesAssetFromAssetEndpoint;
-                                  if (asset.filters) {
-                                    this.setState({
-                                      timeseriesNestedAssetsFromAsset:
-                                        asset.filters
-                                    });
-                                  } else if (asset.pumps) {
-                                    this.setState({
-                                      timeseriesNestedAssetsFromAsset:
-                                        asset.pumps
-                                    });
-                                  }
-                                }}
+                                onKeyUp={e => {}}
                                 inputId={
                                   "notifications_app.select_timeserie_via_nested_asset" +
                                   "_input"


### PR DESCRIPTION
* Make it possible to select a nested asset from the selected asset  (for timeseries alarms)

* When clearing the asset, the nested asset is also cleared.
* when typing in the asset field, the nested asset gets also cleared.