### PR TITLE
make sure aggregation_type none is send with post call

### DIFF
--- a/src/data_management/rasters/RasterForm.js
+++ b/src/data_management/rasters/RasterForm.js
@@ -574,10 +574,9 @@ class RasterFormModel extends Component {
       (this.state.observationType && this.state.observationType.code) ||
       undefined;
 
-    const intAggregationType =
-      (this.state.aggregationType &&
-        this.aggregationTypeStringToInteger(this.state.aggregationType)) ||
-      undefined;
+    const intAggregationType = this.state.aggregationType
+      ? this.aggregationTypeStringToInteger(this.state.aggregationType)
+      : undefined;
 
     const isoIntervalDuration = this.intervalToISODuration(
       this.state.temporalIntervalDays,


### PR DESCRIPTION
Voor nu alleen kleine fix dat we aggregation type wel weer op "none" kunnen zetten.

Grote bug dat aggregation type en observation type niet aan te passen zijn hebben we nog niet gereproduceerd.
Ga nog contact zoeken met Wietze Suijker. 
Kunnen we dit reproduceren ? misschien kan hij ons hiermee helpen.
