### PR TITLE
Remco form initial

### DIFF
--- a/src/data_management/rasters/NewRaster2.js
+++ b/src/data_management/rasters/NewRaster2.js
@@ -26,20 +26,21 @@ const onSubmitExample = (validatedData) => {
 class NewRaster2 extends Component {
   render() {
     return (
-      <ManagementForm onSubmit={onSubmitExample} wizardStyle
-      initial={{
-        first: "This initial was set through the form"
-      }}
+      <ManagementForm onSubmit={onSubmitExample}
+                      initial={{
+                        first: "This initial was set through the form"
+                      }}
+                      wizardStyle
       >
-      <SlushBucket
-      name="sharedWithOrganisation"
-      title="Shared With Organisation"
-      choices={[
-        { value: "abc", display: "aBc" },
-        { value: "nens", display: "nEns" },
-        { value: "home", display: "hOmbre" },
-      ]}
-          readonly={false}
+        <SlushBucket
+          name="sharedWithOrganisation"
+          title="Shared With Organisation"
+          choices={[
+            { value: "abc", display: "aBc" },
+            { value: "nens", display: "nEns" },
+            { value: "home", display: "hOmbre" },
+          ]}
+          readOnly={false}
           placeholder={"search organisations"}
         />
         <DurationField

--- a/src/data_management/rasters/NewRaster2.js
+++ b/src/data_management/rasters/NewRaster2.js
@@ -26,15 +26,19 @@ const onSubmitExample = (validatedData) => {
 class NewRaster2 extends Component {
   render() {
     return (
-      <ManagementForm onSubmit={onSubmitExample} wizardStyle>
-        <SlushBucket
-          name="sharedWithOrganisation"
-          title="Shared With Organisation"
-          choices={[
-            { value: "abc", display: "aBc" },
-            { value: "nens", display: "nEns" },
-            { value: "home", display: "hOmbre" },
-          ]}
+      <ManagementForm onSubmit={onSubmitExample} wizardStyle
+      initial={{
+        first: "This initial was set through the form"
+      }}
+      >
+      <SlushBucket
+      name="sharedWithOrganisation"
+      title="Shared With Organisation"
+      choices={[
+        { value: "abc", display: "aBc" },
+        { value: "nens", display: "nEns" },
+        { value: "home", display: "hOmbre" },
+      ]}
           readonly={false}
           placeholder={"search organisations"}
         />
@@ -74,7 +78,6 @@ class NewRaster2 extends Component {
           name="first"
           title="The first field"
           placeholder="Enter a test"
-          initial="whee"
         />
         <TextInput
           name="test"

--- a/src/forms/DurationField.tsx
+++ b/src/forms/DurationField.tsx
@@ -30,7 +30,7 @@ const fromISOValue = (value: string): durationObject => {
 
   if (value) {
     const match = value.match(isoRegex);
-    console.log('matching ', value, ' with ', isoRegex, ' result ', match);
+
     if (match) {
       return {
         days: parseFloat(match[1]) || 0,

--- a/src/forms/ManagementForm.tsx
+++ b/src/forms/ManagementForm.tsx
@@ -500,7 +500,6 @@ class ManagementForm extends Component<ManagementFormProps, ManagementFormState>
         })}
         {!wizardStyle || this.isLastStep() ?
          <SubmitButton notValidatedSteps={this.notValidatedSteps()} submit={this.submit.bind(this)} /> : null}
-        {JSON.stringify(this.state.formValues, null, 2)}
       </div>
     );
   }

--- a/src/forms/ManagementForm.tsx
+++ b/src/forms/ManagementForm.tsx
@@ -83,6 +83,7 @@ interface FieldProps {
 }
 
 interface ManagementFormProps {
+  initial?: formValues,
   wizardStyle?: boolean,
   children: Component<FieldProps, any>[],
   onSubmit: (validatedData: formValues) => void
@@ -136,12 +137,19 @@ class ManagementForm extends Component<ManagementFormProps, ManagementFormState>
     // A list of disabler functions (or booleans) for each field.
     const formDisablers: {[key: string]: Function | boolean} = {};
 
+    const formInitial = this.props.initial || {};
+
     // Get values from the Field components' props to fill the
     // aforementioned variables.
     children.forEach(child => {
-      const {name, initial, validators, disabled} = child.props;
+      const {name, validators, disabled} = child.props;
 
-      formValues[name] = initial || null;
+      const initial = (
+        'initial' in child.props ? child.props.initial :
+        name in formInitial ? formInitial[name] :
+        null);
+
+      formValues[name] = initial;
       formValidators[name] = validators || [];
       formDisablers[name] = disabled || false;
       allNames.push(name);
@@ -481,6 +489,7 @@ class ManagementForm extends Component<ManagementFormProps, ManagementFormState>
           })}
         {!wizardStyle || this.isLastStep() ?
          <SubmitButton notValidatedSteps={this.notValidatedSteps()} submit={this.submit.bind(this)} /> : null}
+        {JSON.stringify(this.state.formValues, null, 2)}
       </div>
     );
   }

--- a/src/forms/ManagementForm.tsx
+++ b/src/forms/ManagementForm.tsx
@@ -76,6 +76,7 @@ type formValues = {
 interface FieldProps {
   name: string,
   title?: string,
+  readOnly?: true,
   initial?: any,
   subtitle?: string,
   validators?: Function[],
@@ -85,6 +86,7 @@ interface FieldProps {
 interface ManagementFormProps {
   initial?: formValues,
   wizardStyle?: boolean,
+  readOnly?: boolean,
   children: Component<FieldProps, any>[],
   onSubmit: (validatedData: formValues) => void
 };
@@ -419,38 +421,46 @@ class ManagementForm extends Component<ManagementFormProps, ManagementFormState>
       highestFieldSoFar,
       triedToMovePastField
     } = this.state;
-    const { wizardStyle } = this.props;
+    const { wizardStyle, readOnly } = this.props;
 
     return (
       <div>
-        {this.childrenAsArray().map(
-          (child, idx) => {
-            const name: string = child.props.name;
-            const title: string = child.props.title || name;
-            const subtitle: string = child.props.subtitle || '';
-            const validated = formValidated[name];
-            const disabled = formDisabled[name];
-            const errors = formErrors[name];
+      {this.childrenAsArray().map(
+        (child, idx) => {
+          const name: string = child.props.name;
+          const title: string = child.props.title || name;
+          const subtitle: string = child.props.subtitle || '';
+          const validated = formValidated[name];
+          const disabled = formDisabled[name];
+          const errors = formErrors[name];
 
+          if (disabled) {
+            return (
+              <DisabledStep
+                key={"formfield"+idx}
+                step={idx+1}
+                title={title}
+              />
+            );
+          } else {
+            const extraFields: {[key: string]: any} = {
+              value: formValues[name],
+              validated: validated,
+              valueChanged: (value: any) => this.valueChanged(name, value),
+              wizardStyle: wizardStyle,
+              handleEnter: (e: any) => this.handleEnter(idx, e)
+            };
+            if (readOnly) {
+              // If the whole form is readOnly, send this prop to
+              // all children.
+              extraFields.readOnly = true;
+            }
             const childWithExtraFields = React.cloneElement(
               (child as unknown) as ReactElement,
-              {
-                value: formValues[name],
-                validated: validated,
-                valueChanged: (value: any) => this.valueChanged(name, value),
-                wizardStyle: wizardStyle,
-                handleEnter: (e: any) => this.handleEnter(idx, e)
-              });
+              extraFields
+            );
 
-            if (disabled) {
-              return (
-                <DisabledStep
-                  key={"formfield"+idx}
-                  step={idx+1}
-                  title={title}
-                />
-              );
-            } else if (wizardStyle) {
+            if (wizardStyle) {
               return (
                 <WithStep
                   step={idx+1}
@@ -486,7 +496,8 @@ class ManagementForm extends Component<ManagementFormProps, ManagementFormState>
                 </WithStep>
               );
             }
-          })}
+          }
+        })}
         {!wizardStyle || this.isLastStep() ?
          <SubmitButton notValidatedSteps={this.notValidatedSteps()} submit={this.submit.bind(this)} /> : null}
         {JSON.stringify(this.state.formValues, null, 2)}

--- a/src/forms/SlushBucket.tsx
+++ b/src/forms/SlushBucket.tsx
@@ -18,7 +18,7 @@ interface Props {
   title: string,
   name: string,
   placeholder: string,
-  readonly: boolean | undefined,
+  readOnly: boolean | undefined,
   value: valueT,
   choices: choicesT,
   validators?: Function[],
@@ -78,7 +78,7 @@ export default class SlushBucket extends Component<Props, State> {
             className={
               formStyles.FormControl +
               " " +
-              (this.props.readonly ? inputStyles.ReadOnly : "")
+              (this.props.readOnly ? inputStyles.ReadOnly : "")
             }
             placeholder={placeholder}
             onChange={e => this.handleInput(e)}
@@ -86,8 +86,8 @@ export default class SlushBucket extends Component<Props, State> {
               this.handleKeyUp(event);
             }}
             value={this.state.searchString}
-            disabled={this.props.readonly}
-            readOnly={this.props.readonly}
+            disabled={this.props.readOnly}
+            readOnly={this.props.readOnly}
           />
           <div
             style={{
@@ -122,7 +122,7 @@ export default class SlushBucket extends Component<Props, State> {
             <Scrollbars autoHeight autoHeightMin={400} autoHeightMax={400}>
               {choices
                 .filter(choiceItem => {
-                  if (this.props.readonly) {
+                  if (this.props.readOnly) {
                     return false;
                   }
                   if (this.state.searchString === "") {
@@ -184,7 +184,7 @@ export default class SlushBucket extends Component<Props, State> {
                 .map((choiceItem,i) => {
                   return (
                     <div
-                      className={`${styles.SelectedRow} ${this.props.readonly
+                      className={`${styles.SelectedRow} ${this.props.readOnly
                         ? styles.SelectedRowReadonly
                         : ""}`}
                       style={{
@@ -202,7 +202,7 @@ export default class SlushBucket extends Component<Props, State> {
                           );
                         }}
                         style={{
-                          visibility: this.props.readonly ? "hidden" : "visible"
+                          visibility: this.props.readOnly ? "hidden" : "visible"
                         }}
                       />
                     </div>


### PR DESCRIPTION
Rename 'readonly' prop to 'readOnly' for consistency
Allow setting of initial values through an object as ManagementForm prop, if not set on field
Allow setting of readOnly through a ManagementForm prop
