### PR TITLE
Raster date filename using timestamp without colon for Windows user

### DIFF
--- a/src/data_management/rasters/UploadRasterDataMultiple.js
+++ b/src/data_management/rasters/UploadRasterDataMultiple.js
@@ -219,10 +219,6 @@ class UploadRasterDataMultipleModel extends Component {
         dateObjFromFile = new Date()
       };
 
-      // const dateObjFromFile = dateStrFromFile
-      //   ? new Date(dateStrFromFile[0])
-      //   : new Date();
-
       const fileDateValid = this.isValidDateObj(dateObjFromFile);
       return {
         file: e,
@@ -487,6 +483,7 @@ class UploadRasterDataMultipleModel extends Component {
                     <button
                       className={`${buttonStyles.Button} ${buttonStyles.Success}`}
                       style={{ marginTop: 10 }}
+                      title="Timestamp filename format could be YYYY-MM-DDTHH:MM(:SS) or YYYYMMDDTHHMM(SS) with name prefixed or postfixed"
                     >
                       <FormattedMessage
                         id="rasters.raster_upload_browse"

--- a/src/data_management/rasters/UploadRasterDataMultiple.js
+++ b/src/data_management/rasters/UploadRasterDataMultiple.js
@@ -202,10 +202,27 @@ class UploadRasterDataMultipleModel extends Component {
     // convert acceptedFilesToobjectsWithDate
     const acceptedFilesData = newAcceptedFilesNonDuplicates.map(e => {
       const regex = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?/gm;
+      const regexUTC = /\d{8}T(\d{4}|\d{6})?/gm;
       const dateStrFromFile = (e.name + "").match(regex);
-      const dateObjFromFile = dateStrFromFile
-        ? new Date(dateStrFromFile[0])
-        : new Date();
+      
+      //If user upload a file with file name in UTC format without the dash (-) sign then match it with regexUTC
+      const dateStrFromUTCFile = (e.name + "").match(regexUTC);
+      //Use moment.js to re-format the date string from YYYYMMDDTHHMM to YYYY-MM-DDTHH:MM
+      const dateStrReformatted = dateStrFromUTCFile && moment(dateStrFromUTCFile[0]).format("YYYY-MM-DDTHH:mm")
+
+      let dateObjFromFile;
+      if (dateStrFromFile) {
+        dateObjFromFile = new Date(dateStrFromFile[0])
+      } else if (dateStrReformatted) {
+        dateObjFromFile = new Date(dateStrReformatted)
+      } else {
+        dateObjFromFile = new Date()
+      };
+
+      // const dateObjFromFile = dateStrFromFile
+      //   ? new Date(dateStrFromFile[0])
+      //   : new Date();
+
       const fileDateValid = this.isValidDateObj(dateObjFromFile);
       return {
         file: e,


### PR DESCRIPTION
Windows user can now upload temporal raster file in UTC format of YYYYMMDDTHHMM(SS) (without colons).

When hover on BROWSE button, a small popup shows user how to name their file.