### PR TITLE
Fix bug: Change contact group or template in alarm notification form

### DIFF
--- a/src/alarms/notifications/GroupAndTemplateSelect.js
+++ b/src/alarms/notifications/GroupAndTemplateSelect.js
@@ -57,6 +57,12 @@ class GroupAndTemplateSelect extends Component {
     const selectedGroup = groups.find(group => group.id === groupId);
     return selectedGroup ? selectedGroup.name : "Select a group";
   }
+  componentDidMount() {
+    this.setState({
+      selectedGroupId: this.props.groupId,
+      selectedMessageId: this.props.messageId
+    });
+  }
   render() {
     const {
       availableGroups,


### PR DESCRIPTION
Changing contact group or template in alarm notification form doesn't work properly. 
If user changes both fields then it is gonna work. If user changes only 1 field of the 2 then the change will not be made.
The reason for this issue is in GroupAndTemplateSelect.js, selectedMessageId and selectedGroupId in this component state is null when the component first mounted. If user changes only 1 value i.e. message, then the other value (contact group) will be null. This will prevent the function call of this.props.addGroupAndTemplate() in line 25 and line 41 in GroupAndTemplateSelect.js. 
To prevent this from happening, I used componentDidMount to set the state of GroupAndTemplateSelect.js with the value of contact group and message coming from this.props. So they will not be null anymore.