### PR TITLE
Remco clean up tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-lottie": "^1.2.3",
     "react-map-gl": "^6.1.13",
     "react-md-spinner": "^0.3.0",
+    "react-query": "^3.17.2",
     "react-redux": "^7.0.2",
     "react-router-dom": "^5.0.0",
     "react-scripts": "^4.0.1",

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,8 @@ import { connect } from "react-redux";
 import { FormattedMessage, injectIntl } from "react-intl";
 import MDSpinner from "react-md-spinner";
 import { fetchTaskInstance } from "./api/tasks";
+import { queryClient } from './api/hooks';
+import { QueryClientProvider } from 'react-query';
 import {
   addNotification,
   fetchLizardBootstrap,
@@ -50,8 +52,8 @@ class App extends Component {
   //Click the user-profile button open the dropdown
   //Click anywhere outside of the user-profile modal will close the modal
   onUserProfileClick = (e) => {
-    return e.target.id === "user-profile" ? 
-      this.setState({ showProfileList: !this.state.showProfileList }) : 
+    return e.target.id === "user-profile" ?
+      this.setState({ showProfileList: !this.state.showProfileList }) :
       this.setState({ showProfileList: false });
   }
 
@@ -168,8 +170,8 @@ class App extends Component {
   };
 
   render() {
-    if ( 
-      this.props.availableOrganisations.length === 0 && 
+    if (
+      this.props.availableOrganisations.length === 0 &&
       this.props.isFetchingOrganisations === false &&
       this.props.timesFetchedOrganisations > 0
     ) {
@@ -185,7 +187,7 @@ class App extends Component {
       // should redirect to <customer_url>.lizard.net/management/ on prod
       this.props.history.push("/");
     }
-    
+
     if (!this.props.isAuthenticated || !this.props.selectedOrganisation) {
       return (
         <div className={styles.MDSpinner}>
@@ -200,167 +202,169 @@ class App extends Component {
       const { showOrganisationSwitcher } = this.state;
 
       return (
-        <div className={styles.App} onClick={this.onUserProfileClick}>
-          <div className={`${styles.Primary}`}>
-            <div className={gridStyles.Container}>
-              <div className={gridStyles.Row}>
-                <div
-                  style={{ height: "55px" }}
-                  className={`${gridStyles.colLg4} ${gridStyles.colMd4} ${gridStyles.colSm4} ${gridStyles.colXs12}`}
-                >
-                  <NavLink to="/" title={"client-version: " +packageJson.version}>
-                    <img src={`${lizardIcon}`} alt="Lizard logo" className={styles.LizardLogo} />
-                  </NavLink>
-                </div>
-                <div
-                  className={`${gridStyles.colLg8} ${gridStyles.colMd8} ${gridStyles.colSm8} ${gridStyles.colXs12}`}
-                >
-                  <div className={styles.TopNav}>
-                    <div style={{ display: "none" }}>
-                      <a href="#apps">
-                        <i className={`material-icons ${styles.AppIcon}`}>
-                          apps
-                        </i>
-                        Apps
-                      </a>
-                    </div>
-                    <div
-                      className={styles.Profile}
-                      onClick={() => {
-                        this.setState({
-                          showUploadQueue: !this.state.showUploadQueue
-                        })
-                      }}
-                    >
-                      <div>
-                        <i className="fa fa-upload" style={{ paddingRight: 8 }} />
-                        {this.props.filesInProcess && this.props.filesInProcess.length > 0 ? <span className={styles.NavNotification}>!</span> : null}
-                        Upload queue
+        <QueryClientProvider client={queryClient}>
+          <div className={styles.App} onClick={this.onUserProfileClick}>
+            <div className={`${styles.Primary}`}>
+              <div className={gridStyles.Container}>
+                <div className={gridStyles.Row}>
+                  <div
+                    style={{ height: "55px" }}
+                    className={`${gridStyles.colLg4} ${gridStyles.colMd4} ${gridStyles.colSm4} ${gridStyles.colXs12}`}
+                  >
+                    <NavLink to="/" title={"client-version: " +packageJson.version}>
+                      <img src={`${lizardIcon}`} alt="Lizard logo" className={styles.LizardLogo} />
+                    </NavLink>
+                  </div>
+                  <div
+                    className={`${gridStyles.colLg8} ${gridStyles.colMd8} ${gridStyles.colSm8} ${gridStyles.colXs12}`}
+                  >
+                    <div className={styles.TopNav}>
+                      <div style={{ display: "none" }}>
+                        <a href="#apps">
+                          <i className={`material-icons ${styles.AppIcon}`}>
+                            apps
+                          </i>
+                          Apps
+                        </a>
                       </div>
-                    </div>
-                    <div
-                      className={styles.OrganisationLinkContainer}
-                      onClick={() =>
-                        this.setState({
-                          showOrganisationSwitcher: true
-                        })
-                      }
-                    >
-                      <button
-                        className={`${buttonStyles.ButtonLink} ${styles.OrganisationLink}`}
-                        title={
-                          selectedOrganisation
-                            ? selectedOrganisation.name
-                            : "Select organisation"
+                      <div
+                        className={styles.Profile}
+                        onClick={() => {
+                          this.setState({
+                            showUploadQueue: !this.state.showUploadQueue
+                          })
+                        }}
+                      >
+                        <div>
+                          <i className="fa fa-upload" style={{ paddingRight: 8 }} />
+                          {this.props.filesInProcess && this.props.filesInProcess.length > 0 ? <span className={styles.NavNotification}>!</span> : null}
+                          Upload queue
+                        </div>
+                      </div>
+                      <div
+                        className={styles.OrganisationLinkContainer}
+                        onClick={() =>
+                          this.setState({
+                            showOrganisationSwitcher: true
+                          })
                         }
                       >
-                        <i className="fa fa-sort" />
-                        &nbsp;&nbsp;
-                        {selectedOrganisation
+                        <button
+                          className={`${buttonStyles.ButtonLink} ${styles.OrganisationLink}`}
+                          title={
+                          selectedOrganisation
                           ? selectedOrganisation.name
-                          : "Select organisation"}
-                      </button>
-                    </div>
-                    <div
-                      className={styles.Profile}
-                      id="user-profile"
-                    >
-                      <div className={styles.UserProfile} id="user-profile">
-                        <i className="fa fa-user" style={{ paddingRight: 8 }} id="user-profile"/>
-                        <span className={styles.UserName} id="user-profile">{firstName}</span>
-                      </div>
-                      {this.state.showProfileList && this.renderProfileList()}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div className={`${styles.Secondary}`}>
-            <div className={gridStyles.Container}>
-              <div className={gridStyles.Row}>
-                <Breadcrumbs
-                  // The same location is needed to calculate the breadcrumbs.
-                  location= {this.props.location}
-                />
-              </div>
-            </div>
-          </div>
-          <div className={gridStyles.Container + " " + styles.AppContent}>
-                <Routes/>
-          </div>
-          <footer className={styles.Footer}>
-            <div className={gridStyles.Container}>
-              <div className={gridStyles.Row}>
-                <div
-                  className={`${styles.FooterLeft} ${gridStyles.colLg6} ${gridStyles.colMd6} ${gridStyles.colSm6} ${gridStyles.colXs6}`}
-                >
-                  <a
-                    href="https://docs.lizard.net/a_lizard.html"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <FormattedMessage
-                      id="index.documentation"
-                      defaultMessage="Documentation"
-                    />
-                    &nbsp;
-                    <i
-                      className={`${styles.DocumentationHyperlink} material-icons`}
-                    >
-                      local_library
-                    </i>
-                  </a>
-                </div>
-                <div
-                  className={`${styles.FooterRight} ${gridStyles.colLg6} ${gridStyles.colMd6} ${gridStyles.colSm6} ${gridStyles.colXs6}`}
-                >
-                  <div className={styles.FooterRightWrapper}>
-                    <div style={{ margin: "0 10px 0 10px" }}>
-                      <LanguageSwitcher
-                        locale={preferredLocale}
-                        languages={[
-                          { code: "nl", language: "Nederlands" },
-                          { code: "en", language: "English" }
-                        ]}
-                      />
-                    </div>
-                    <div>
-                      <a
-                        href="https://nelen-schuurmans.topdesk.net/tas/public/ssp"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        <i
-                          className={`${styles.SupportHyperlink} material-icons`}
+                          : "Select organisation"
+                          }
                         >
-                          headset_mic
-                        </i>
-                        &nbsp;
-                        <FormattedMessage
-                          id="index.support"
-                          defaultMessage="Support"
-                        />
-                      </a>
+                          <i className="fa fa-sort" />
+        &nbsp;&nbsp;
+        {selectedOrganisation
+       ? selectedOrganisation.name
+       : "Select organisation"}
+                        </button>
+                      </div>
+                      <div
+                        className={styles.Profile}
+                        id="user-profile"
+                      >
+                        <div className={styles.UserProfile} id="user-profile">
+                          <i className="fa fa-user" style={{ paddingRight: 8 }} id="user-profile"/>
+                          <span className={styles.UserName} id="user-profile">{firstName}</span>
+                        </div>
+                        {this.state.showProfileList && this.renderProfileList()}
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
-          </footer>
-          {showOrganisationSwitcher ? (
-            <OrganisationSwitcher
-              handleClose={() =>
-                this.setState({ showOrganisationSwitcher: false })}
-            />
-          ) : null}
-          <Snackbar />
-          {this.state.showUploadQueue ? (
-            <UploadQueue
-              handleClose={() => this.setState({ showUploadQueue: false })}
-            />
-          ) : null}
+            <div className={`${styles.Secondary}`}>
+              <div className={gridStyles.Container}>
+                <div className={gridStyles.Row}>
+                  <Breadcrumbs
+                  // The same location is needed to calculate the breadcrumbs.
+                    location= {this.props.location}
+                  />
+                </div>
+              </div>
+            </div>
+            <div className={gridStyles.Container + " " + styles.AppContent}>
+              <Routes/>
+            </div>
+            <footer className={styles.Footer}>
+              <div className={gridStyles.Container}>
+                <div className={gridStyles.Row}>
+                  <div
+                    className={`${styles.FooterLeft} ${gridStyles.colLg6} ${gridStyles.colMd6} ${gridStyles.colSm6} ${gridStyles.colXs6}`}
+                  >
+                    <a
+                      href="https://docs.lizard.net/a_lizard.html"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <FormattedMessage
+                        id="index.documentation"
+                        defaultMessage="Documentation"
+                      />
+        &nbsp;
+        <i
+          className={`${styles.DocumentationHyperlink} material-icons`}
+        >
+          local_library
+        </i>
+                    </a>
+                  </div>
+                  <div
+                    className={`${styles.FooterRight} ${gridStyles.colLg6} ${gridStyles.colMd6} ${gridStyles.colSm6} ${gridStyles.colXs6}`}
+                  >
+                    <div className={styles.FooterRightWrapper}>
+                      <div style={{ margin: "0 10px 0 10px" }}>
+                        <LanguageSwitcher
+                          locale={preferredLocale}
+                          languages={[
+                            { code: "nl", language: "Nederlands" },
+                            { code: "en", language: "English" }
+                          ]}
+                        />
+                      </div>
+                      <div>
+                        <a
+                          href="https://nelen-schuurmans.topdesk.net/tas/public/ssp"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          <i
+                            className={`${styles.SupportHyperlink} material-icons`}
+                          >
+                            headset_mic
+                          </i>
+        &nbsp;
+        <FormattedMessage
+        id="index.support"
+        defaultMessage="Support"
+        />
+        </a>
         </div>
+        </div>
+        </div>
+        </div>
+        </div>
+        </footer>
+        {showOrganisationSwitcher ? (
+          <OrganisationSwitcher
+            handleClose={() =>
+              this.setState({ showOrganisationSwitcher: false })}
+          />
+        ) : null}
+        <Snackbar />
+        {this.state.showUploadQueue ? (
+          <UploadQueue
+            handleClose={() => this.setState({ showUploadQueue: false })}
+          />
+        ) : null}
+                      </div>
+        </QueryClientProvider>
       );
     }
   }

--- a/src/alarms/alarmgroups/GroupTable.tsx
+++ b/src/alarms/alarmgroups/GroupTable.tsx
@@ -30,7 +30,7 @@ export const GroupTable: React.FC<RouteComponentProps> = (props) =>  {
   const columnDefinitions = [
     {
       titleRenderFunction: () => "Name",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={row.name}
@@ -41,7 +41,7 @@ export const GroupTable: React.FC<RouteComponentProps> = (props) =>  {
     },
     {
       titleRenderFunction: () =>  "Size",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
         >
@@ -54,10 +54,10 @@ export const GroupTable: React.FC<RouteComponentProps> = (props) =>  {
       renderFunction: (row: any, tableData:any, setTableData:any, triggerReloadWithCurrentPage:any, triggerReloadWithBasePage:any) => {
         return (
             <TableActionButtons
-              tableRow={row} 
+              tableRow={row}
               tableData={tableData}
-              setTableData={setTableData} 
-              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage} 
+              setTableData={setTableData}
+              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage}
               triggerReloadWithBasePage={triggerReloadWithBasePage}
               editUrl={`${navigationUrl}/${row.id}`}
               actions={[
@@ -88,10 +88,10 @@ export const GroupTable: React.FC<RouteComponentProps> = (props) =>  {
       explanationText={"Groups are made of your contacts. In this screen, you can manage them by adding or deleting contacts. You can also add or delete groups for your alarm messages."}
       backUrl={"/alarms"}
     >
-      <TableStateContainer 
-        gridTemplateColumns={"10% 60% 20% 10%"} 
+      <TableStateContainer
+        gridTemplateColumns={"10% 60% 20% 10%"}
         columnDefinitions={columnDefinitions}
-        baseUrl={`${baseUrl}?`} 
+        baseUrl={`${baseUrl}?`}
         checkBoxActions={[
           {
             displayValue: "Delete",
@@ -103,7 +103,7 @@ export const GroupTable: React.FC<RouteComponentProps> = (props) =>  {
         newItemOnClick={handleNewContactClick}
         filterOptions={[
           {
-            value: 'name__icontains=',
+            value: 'name__icontains',
             label: 'Name'
           }
         ]}

--- a/src/alarms/alarmtemplates/TemplateTable.tsx
+++ b/src/alarms/alarmtemplates/TemplateTable.tsx
@@ -30,7 +30,7 @@ export const TemplateTable: React.FC<RouteComponentProps> = (props) =>  {
   const columnDefinitions = [
     {
       titleRenderFunction: () => "Name",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={row.name}
@@ -41,7 +41,7 @@ export const TemplateTable: React.FC<RouteComponentProps> = (props) =>  {
     },
     {
       titleRenderFunction: () =>  "Type",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={row.type}
@@ -55,10 +55,10 @@ export const TemplateTable: React.FC<RouteComponentProps> = (props) =>  {
       renderFunction: (row: any, tableData:any, setTableData:any, triggerReloadWithCurrentPage:any, triggerReloadWithBasePage:any) => {
         return (
             <TableActionButtons
-              tableRow={row} 
+              tableRow={row}
               tableData={tableData}
-              setTableData={setTableData} 
-              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage} 
+              setTableData={setTableData}
+              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage}
               triggerReloadWithBasePage={triggerReloadWithBasePage}
               editUrl={`${navigationUrl}/${row.id}`}
               actions={[
@@ -86,13 +86,13 @@ export const TemplateTable: React.FC<RouteComponentProps> = (props) =>  {
       imgUrl={templateIcon}
       imgAltDescription={"Template icon"}
       headerText={"Templates"}
-      explanationText={"Templates are used to create messages for your alarms. You can choose between an email or text message."} 
+      explanationText={"Templates are used to create messages for your alarms. You can choose between an email or text message."}
       backUrl={"/alarms"}
     >
-        <TableStateContainer 
-          gridTemplateColumns={"10% 70% 10% 10%"} 
+        <TableStateContainer
+          gridTemplateColumns={"10% 70% 10% 10%"}
           columnDefinitions={columnDefinitions}
-          baseUrl={`${baseUrl}?`} 
+          baseUrl={`${baseUrl}?`}
           checkBoxActions={[
             {
               displayValue: "Delete",
@@ -104,7 +104,7 @@ export const TemplateTable: React.FC<RouteComponentProps> = (props) =>  {
           newItemOnClick={handleNewContactClick}
           filterOptions={[
             {
-              value: 'name__icontains=',
+              value: 'name__icontains',
               label: 'Name'
             }
           ]}

--- a/src/alarms/contacts/ContactTable.tsx
+++ b/src/alarms/contacts/ContactTable.tsx
@@ -40,7 +40,7 @@ export const ContactTable: React.FC<RouteComponentProps> = (props) =>  {
   const columnDefinitions = [
     {
       titleRenderFunction: () => "First name",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={getDjangoUserOrContactUser(row).first_name}
@@ -51,7 +51,7 @@ export const ContactTable: React.FC<RouteComponentProps> = (props) =>  {
     },
     {
       titleRenderFunction: () =>  "Last name",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={getDjangoUserOrContactUser(row).last_name}
@@ -62,7 +62,7 @@ export const ContactTable: React.FC<RouteComponentProps> = (props) =>  {
     },
     {
       titleRenderFunction: () => "Email",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={getDjangoUserOrContactUser(row).email}
@@ -73,7 +73,7 @@ export const ContactTable: React.FC<RouteComponentProps> = (props) =>  {
     },
     {
       titleRenderFunction: () =>  "Telephone",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={getDjangoUserOrContactUser(row).phone_number}
@@ -87,10 +87,10 @@ export const ContactTable: React.FC<RouteComponentProps> = (props) =>  {
       renderFunction: (row: any, tableData:any, setTableData:any, triggerReloadWithCurrentPage:any, triggerReloadWithBasePage:any) => {
         return (
             <TableActionButtons
-              tableRow={row} 
+              tableRow={row}
               tableData={tableData}
-              setTableData={setTableData} 
-              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage} 
+              setTableData={setTableData}
+              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage}
               triggerReloadWithBasePage={triggerReloadWithBasePage}
               editUrl={`${navigationUrl}/${row.id}`}
               actions={[
@@ -122,13 +122,13 @@ export const ContactTable: React.FC<RouteComponentProps> = (props) =>  {
       imgUrl={contactIcon}
       imgAltDescription={"Contact icon"}
       headerText={"Contacts"}
-      explanationText={"Your contacts contain an email address, phone number and a name. Add these contacts to group to send them alarm messages when your thresholds are triggered."} 
+      explanationText={"Your contacts contain an email address, phone number and a name. Add these contacts to group to send them alarm messages when your thresholds are triggered."}
       backUrl={"/alarms"}
     >
-        <TableStateContainer 
-          gridTemplateColumns={"6% 18% 18% 32% 18% 8%"} 
+        <TableStateContainer
+          gridTemplateColumns={"6% 18% 18% 32% 18% 8%"}
           columnDefinitions={columnDefinitions}
-          baseUrl={`${baseUrl}?`} 
+          baseUrl={`${baseUrl}?`}
           checkBoxActions={[
             {
               displayValue: "Delete",
@@ -140,11 +140,11 @@ export const ContactTable: React.FC<RouteComponentProps> = (props) =>  {
           newItemOnClick={handleNewContactClick}
           filterOptions={[
             {
-              value: 'first_name__icontains=',
+              value: 'first_name__icontains',
               label: 'First name'
             },
             {
-              value: 'last_name__icontains=',
+              value: 'last_name__icontains',
               label: 'Last name'
             }
           ]}

--- a/src/alarms/notifications/raster_alarms/RasterAlarmTable.tsx
+++ b/src/alarms/notifications/raster_alarms/RasterAlarmTable.tsx
@@ -53,7 +53,7 @@ export const RasterAlarmTableComponent: React.FC<DispatchProps & RouteComponentP
   const columnDefinitions = [
     {
       titleRenderFunction: () => "Name",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={row.name}
@@ -64,7 +64,7 @@ export const RasterAlarmTableComponent: React.FC<DispatchProps & RouteComponentP
     },
     {
       titleRenderFunction: () =>  "Recipients",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
         >
@@ -74,7 +74,7 @@ export const RasterAlarmTableComponent: React.FC<DispatchProps & RouteComponentP
     },
     {
       titleRenderFunction: () => "Status",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
         >
@@ -87,10 +87,10 @@ export const RasterAlarmTableComponent: React.FC<DispatchProps & RouteComponentP
       renderFunction: (row: any, tableData:any, setTableData:any, triggerReloadWithCurrentPage:any, triggerReloadWithBasePage:any) => {
         return (
             <TableActionButtons
-              tableRow={row} 
+              tableRow={row}
               tableData={tableData}
-              setTableData={setTableData} 
-              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage} 
+              setTableData={setTableData}
+              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage}
               triggerReloadWithBasePage={triggerReloadWithBasePage}
               editUrl={`${navigationUrl}/${row.uuid}`}
               actions={[
@@ -122,13 +122,13 @@ export const RasterAlarmTableComponent: React.FC<DispatchProps & RouteComponentP
       imgUrl={alarmIcon}
       imgAltDescription={"Alarm icon"}
       headerText={"Raster Alarms"}
-      explanationText={"Alarms consist of a name, template, thresholds and recipients. You can create, (de)activate or delete your alarms here."} 
+      explanationText={"Alarms consist of a name, template, thresholds and recipients. You can create, (de)activate or delete your alarms here."}
       backUrl={"/alarms/notifications"}
     >
-        <TableStateContainer 
-          gridTemplateColumns={"10% 40% 20% 20% 10%"} 
+        <TableStateContainer
+          gridTemplateColumns={"10% 40% 20% 20% 10%"}
           columnDefinitions={columnDefinitions}
-          baseUrl={`${baseUrl}?`} 
+          baseUrl={`${baseUrl}?`}
           checkBoxActions={[
             {
               displayValue: "Delete",
@@ -140,7 +140,7 @@ export const RasterAlarmTableComponent: React.FC<DispatchProps & RouteComponentP
           newItemOnClick={handleNewContactClick}
           filterOptions={[
             {
-              value: 'name__icontains=',
+              value: 'name__icontains',
               label: 'Name'
             }
           ]}

--- a/src/alarms/notifications/timeseries_alarms/TimeseriesAlarmTable.tsx
+++ b/src/alarms/notifications/timeseries_alarms/TimeseriesAlarmTable.tsx
@@ -53,7 +53,7 @@ export const TimeseriesAlarmTableComponent: React.FC<DispatchProps & RouteCompon
   const columnDefinitions = [
     {
       titleRenderFunction: () => "Name",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={row.name}
@@ -64,7 +64,7 @@ export const TimeseriesAlarmTableComponent: React.FC<DispatchProps & RouteCompon
     },
     {
       titleRenderFunction: () =>  "Recipients",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
         >
@@ -74,7 +74,7 @@ export const TimeseriesAlarmTableComponent: React.FC<DispatchProps & RouteCompon
     },
     {
       titleRenderFunction: () => "Status",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
         >
@@ -87,10 +87,10 @@ export const TimeseriesAlarmTableComponent: React.FC<DispatchProps & RouteCompon
       renderFunction: (row: any, tableData:any, setTableData:any, triggerReloadWithCurrentPage:any, triggerReloadWithBasePage:any) => {
         return (
             <TableActionButtons
-              tableRow={row} 
+              tableRow={row}
               tableData={tableData}
-              setTableData={setTableData} 
-              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage} 
+              setTableData={setTableData}
+              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage}
               triggerReloadWithBasePage={triggerReloadWithBasePage}
               editUrl={`${navigationUrl}/${row.uuid}`}
               actions={[
@@ -122,13 +122,13 @@ export const TimeseriesAlarmTableComponent: React.FC<DispatchProps & RouteCompon
       imgUrl={alarmIcon}
       imgAltDescription={"Alarm icon"}
       headerText={"Time series Alarms"}
-      explanationText={"Alarms consist of a name, template, thresholds and recipients. You can create, (de)activate or delete your alarms here."} 
+      explanationText={"Alarms consist of a name, template, thresholds and recipients. You can create, (de)activate or delete your alarms here."}
       backUrl={"/alarms/notifications"}
     >
-        <TableStateContainer 
-          gridTemplateColumns={"10% 40% 20% 20% 10%"} 
+        <TableStateContainer
+          gridTemplateColumns={"10% 40% 20% 20% 10%"}
           columnDefinitions={columnDefinitions}
-          baseUrl={`${baseUrl}?`} 
+          baseUrl={`${baseUrl}?`}
           checkBoxActions={[
             {
               displayValue: "Delete",
@@ -140,7 +140,7 @@ export const TimeseriesAlarmTableComponent: React.FC<DispatchProps & RouteCompon
           newItemOnClick={handleNewContactClick}
           filterOptions={[
             {
-              value: 'name__icontains=',
+              value: 'name__icontains',
               label: 'Name'
             }
           ]}

--- a/src/api/hooks.ts
+++ b/src/api/hooks.ts
@@ -1,0 +1,150 @@
+import { useState } from 'react';
+import { QueryClient, useQuery, useQueryClient } from 'react-query';
+
+export type Params = Record<string, string|number>;
+
+// Query client is set using the global provider in App.js!
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000,
+      retry: false as const,
+      refetchOnMount: false as const,
+      // @ts-ignore
+      refetchOnWindowsFocus: false as const,
+      refetchOnReconnect: true as const,
+      refetchIntervalInBackground: true as const,
+      refetchInterval: false as const,
+    }
+  }
+});
+
+export function combineUrlAndParams(url: string, params: Params) {
+  let query = Object.keys(params).map(
+    k => encodeURIComponent(k) + '=' + encodeURIComponent(params[k])
+  ).join('&');
+
+  if (query) {
+    if (url.indexOf('?') >= 0) {
+      return url + '&' + query;
+    } else {
+      return url + '?' + query;
+    }
+  }
+  return url;
+}
+
+// Error to throw if status code isn't 2xx
+export class FetchError extends Error {
+  constructor(public res: Response, message?: string) {
+    super(message)
+  }
+}
+
+export async function basicFetchFunction(
+  baseUrl: string,
+  params: Params
+) {
+  const response = await fetch(combineUrlAndParams(baseUrl, params), {
+    method: 'GET',
+    credentials: "same-origin",
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    }
+  });
+
+  if (response.ok) {
+    const json = await response.json();
+
+    let nextUrl = json.next;
+    let previousUrl = json.previous;
+    // This hack is for development; turn absolute URLs into local ones.
+    if (nextUrl) {
+      nextUrl = nextUrl.split('lizard.net')[1];
+    }
+    if (previousUrl) {
+      previousUrl = previousUrl.split('lizard.net')[1];
+    }
+    // This is how Lizard API v4 formats list responses.
+    return {
+      nextUrl,
+      previousUrl,
+      data: json.results
+    };
+  } else {
+    throw new FetchError(response, `Received status: ${response.status}`)
+  }
+}
+
+
+export function useTableData(baseUrl: string, params: Params, fetchFunction: typeof basicFetchFunction = basicFetchFunction) {
+  const queryClient = useQueryClient();
+  const [currentUrl, setCurrentUrl] = useState<string|null>(null);
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const [currentPageSize, setCurrentPageSize] = useState<number>(10);
+
+  const paginatedParams = {
+    ...params,
+    page_size: currentPageSize,
+    page: currentPage
+  }
+
+  // Use a combined key that always has the same baseUrl, so we can invalidate all
+  // versions at once. If using next/previous pagination, use the full URL as the
+  // second part on later pages, otherwise make a string of the params.
+  const fetchKey = [baseUrl, currentUrl || paginatedParams];
+
+  let queryFunction = (
+    currentUrl ? () => basicFetchFunction(currentUrl, {}) : () => fetchFunction(baseUrl, paginatedParams));
+
+  const query = useQuery(fetchKey, queryFunction);
+
+  const status = query.status; // 'loading', 'error', or 'success'
+  const data = status === 'success' ? query.data! : {data: undefined, nextUrl: undefined, previousUrl: undefined};
+
+  const setPage = (page: number) => {
+    setCurrentPage(page);
+    setCurrentUrl(null);
+  };
+
+  const setPageSize = (pageSize: number) => {
+    setCurrentPageSize(pageSize);
+    setCurrentPage(1);
+    setCurrentUrl(null);
+  };
+
+  // This lacks a way to notice that we reached the end of the data
+  // use count in some way for non-nextUrl pagination.
+  const nextPage = (
+    data.nextUrl ?
+      () => setCurrentUrl(data.nextUrl) :
+      () => setPage(currentPage + 1)
+  );
+  const previousPage = (
+    data.previousUrl ?
+      () => setCurrentUrl(data.previousUrl) :
+      currentPage > 1 ? () => setPage(currentPage - 1) : undefined);
+
+  // Return response and a set of useful functions for paginations and resetting
+  return {
+    status: query.status, // 'loading', 'error', or 'success'
+    tableData: query.status === 'success' ? query.data.data : [],
+    error: query.status === 'error' ? query.error : null,
+
+    setPage,
+    pageSize: currentPageSize,
+    setPageSize,
+    nextPage,
+    previousPage,
+    firstPage: () => setPage(1),
+    reload: () => {
+      // Invalidate all queries with a key that starts with this
+      queryClient.invalidateQueries(baseUrl)
+    },
+    reloadToFirstPage: () => {
+      queryClient.invalidateQueries(baseUrl);
+      setPage(1);
+    }
+  }
+}

--- a/src/components/MapViewerRasterLayerTable.tsx
+++ b/src/components/MapViewerRasterLayerTable.tsx
@@ -18,7 +18,7 @@ export const MapViewerRasterLayerTable: React.FC<Props> = ({setSelectedRasters})
   const columnDefinitions = [
     {
       titleRenderFunction: () => "Name",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={row.name}
@@ -30,7 +30,7 @@ export const MapViewerRasterLayerTable: React.FC<Props> = ({setSelectedRasters})
     },
     {
       titleRenderFunction: () =>  "Based on",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={row.is_geoblock ? 'Geoblock' : 'Raster source'}
@@ -49,7 +49,7 @@ export const MapViewerRasterLayerTable: React.FC<Props> = ({setSelectedRasters})
     },
     {
       titleRenderFunction: () =>  "User",
-      renderFunction: (row: any) =>  
+      renderFunction: (row: any) =>
       <span
         className={tableStyles.CellEllipsis}
         title={row.supplier}
@@ -66,10 +66,10 @@ export const MapViewerRasterLayerTable: React.FC<Props> = ({setSelectedRasters})
   ];
 
   return (
-        <TableStateContainer 
-          gridTemplateColumns={"8% 28% 22% 18% 16%"} 
+        <TableStateContainer
+          gridTemplateColumns={"8% 28% 22% 18% 16%"}
           columnDefinitions={columnDefinitions}
-          baseUrl={`${baseUrl}?`} 
+          baseUrl={`${baseUrl}?`}
           checkBoxActions={[
             {
               displayValue: "Add to map",
@@ -79,10 +79,10 @@ export const MapViewerRasterLayerTable: React.FC<Props> = ({setSelectedRasters})
             },
           ]}
           filterOptions={[
-            {value: 'name__icontains=', label: 'Name'},
+            {value: 'name__icontains', label: 'Name'},
             {value: 'uuid=', label: 'UUID'},
           ]}
-          defaultUrlParams={'&scenario__isnull=true'} // to exclude 3Di scenario rasters
+          defaultUrlParams={{scenario__isnull: 'true'}} // to exclude 3Di scenario rasters
         />
   );
 }

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,54 +1,57 @@
 import React from 'react';
 import styles from './Pagination.module.css';
 import paginationArrowIcon from '../images/pagination_arrow.svg';
-// import { FormattedMessage, } from "react-intl";
 
 interface Props {
-  page1Url: string;
-  previousUrl: string | null;
-  nextUrl: string | null;
-  itemsPerPage: number;
-  reloadFromUrl: (url: string)=> void;
-  setItemsPerPage: (amountItems: number)=> void;
+  toPage1?: () => void;
+  toPrevious?: () => void;
+  toNext?: () => void;
+
+  itemsPerPageChoices?: number[];
+  itemsPerPage?: number;
+  setItemsPerPage?: (amount: number) => void;
 }
 
-const Pagination: React.FC<Props> = ({page1Url,previousUrl, nextUrl, itemsPerPage, reloadFromUrl, setItemsPerPage}) => {
+const Pagination: React.FC<Props> = ({
+  toPage1,
+  toPrevious,
+  toNext,
+  itemsPerPageChoices = [10, 20, 40],
+  itemsPerPage,
+  setItemsPerPage
+}) => {
   return (
-      <div  className={styles.Pagination}
+      <div className={styles.Pagination}
         style={{
           display: "flex",
           justifyContent: "flex-end",
         }}
       >
         <div>
-          <button title={"to first page"} disabled={previousUrl===""} onClick={()=>reloadFromUrl(page1Url)}>
+          <button title={"to first page"} disabled={toPage1 === undefined} onClick={toPage1}>
             <img alt="" style={{transform:"scaleX(-1"}} src={paginationArrowIcon}/>
             <img alt="to first page" style={{transform:"scaleX(-1"}} src={paginationArrowIcon}/>
           </button>
-          <button disabled={!previousUrl} onClick={() => previousUrl && reloadFromUrl(previousUrl)}>
+          <button disabled={toPrevious === undefined} onClick={toPrevious}>
             <img alt="to previous page" style={{transform:"scaleX(-1"}} src={paginationArrowIcon}/>
           </button>
-          <button disabled={!nextUrl} onClick={() => nextUrl && reloadFromUrl(nextUrl)}>
+          <button disabled={toNext === undefined} onClick={toNext}>
             <img alt="to next page" src={paginationArrowIcon}/>
           </button>
-          <label>
-            
-            {/* <FormattedMessage
-                id="pagination.label_items_per_page"
-                defaultMessage="Items per page:"
-            /> */}
-            Items per page:
-            <select
-              value={itemsPerPage}
-              onChange={event => setItemsPerPage(parseInt(event.target.value))}
-            >
-              <option value="10">10</option>
-              <option value="20">20</option>
-              <option value="40">40</option>
-            </select>
-          </label>
+          {setItemsPerPage !== undefined ? (
+            <label>
+              Items per page:
+              <select
+                value={itemsPerPage}
+                onChange={event => setItemsPerPage!(parseInt(event.target.value))}
+              >
+                {itemsPerPageChoices.map((choice) => (
+                  <option key={choice} value={choice}>{choice}</option>
+                ))}
+              </select>
+            </label>
+          ) : null}
         </div>
-        
       </div>
   )
 };

--- a/src/components/TableStateContainer.tsx
+++ b/src/components/TableStateContainer.tsx
@@ -24,7 +24,7 @@ interface checkboxAction {
 interface Props {
   gridTemplateColumns: string;
   columnDefinitions: ColumnDefinition[];
-  baseUrl: string; 
+  baseUrl: string;
   checkBoxActions: checkboxAction[];
   filterOptions?: Value[];
   newItemOnClick?: () => void | null;
@@ -87,8 +87,8 @@ const TableStateContainer: React.FC<Props> = ({
     (defaultUrlParams ? defaultUrlParams : '');
 
   const url = queryCheckBox && queryCheckBoxState? queryCheckBox.adaptUrlFunction(preUrl) : preUrl
-    
-  useEffect(() => { 
+
+  useEffect(() => {
     if (currentUrl !== "" && currentUrl === apiResponse.currentUrl) {
       apiResponse.response.results && setTableData(apiResponse.response.results);
       // make sure no checkboxes are checked outside of current page !
@@ -102,7 +102,7 @@ const TableStateContainer: React.FC<Props> = ({
     }
   }, [apiResponse, currentUrl]);
 
-  useEffect(() => { 
+  useEffect(() => {
     fetchWithUrl(url);
   }, [url]);
 
@@ -160,8 +160,8 @@ const TableStateContainer: React.FC<Props> = ({
   })
 
   const checkBoxColumnDefinition: ColumnDefinition = {
-    titleRenderFunction: () => 
-      <Checkbox  
+    titleRenderFunction: () =>
+      <Checkbox
         checked={areAllOnCurrentPageChecked()}
         onChange={()=>{
           if (areAllOnCurrentPageChecked()) {
@@ -171,19 +171,19 @@ const TableStateContainer: React.FC<Props> = ({
           }
         }}
       />,
-    renderFunction: (row: any) => 
-      <Checkbox 
-        checked={row.checkboxChecked} 
+    renderFunction: (row: any) =>
+      <Checkbox
+        checked={row.checkboxChecked}
         onChange={()=>{
           if (row.checkboxChecked) removeUuidFromCheckBoxes(getRowIdentifier(row))
           else addUuidToCheckBoxes(getRowIdentifier(row))
-        }} 
+        }}
       />,
       orderingField: null,
   };
 
-  const columnDefinitionsPlusCheckbox = 
-    checkBoxActions.length > 0 ?  
+  const columnDefinitionsPlusCheckbox =
+    checkBoxActions.length > 0 ?
       [checkBoxColumnDefinition].concat(columnDefinitions)
       :
       columnDefinitions
@@ -256,53 +256,53 @@ const TableStateContainer: React.FC<Props> = ({
         }}
       >
         {filterOptions && filterOptions.length > 0 ?
-          <div
-            style={{
-              display: 'flex',
-              position: 'relative',
-            }}
-          >
-            <TableSearchBox
-              onChange={event=>{
-                const newValue = event.target.value;
-                setSearchInput(newValue);
-              }}
-              onClear={()=>setSearchInput("")}
-              value={searchInput}
-              placeholder={"Type to search"}
-            />
-            {filterOptions.length > 1 ? (
-              <TableSearchToggle
-                options={filterOptions}
-                value={selectedFilterOption}
-                valueChanged={option => setSelectedFilterOption(option)}
-              />
-            ) : null}
-            <TableSearchToggleHelpText
-              filterOption={selectedFilterOption}
-            />
-          </div>
-        : <div />}
+                                                 <div
+                                                   style={{
+                                                     display: 'flex',
+                                                     position: 'relative',
+                                                   }}
+                                                 >
+                                                   <TableSearchBox
+                                                     onChange={event=>{
+                                                       const newValue = event.target.value;
+                                                       setSearchInput(newValue);
+                                                     }}
+                                                     onClear={()=>setSearchInput("")}
+                                                     value={searchInput}
+                                                     placeholder={"Type to search"}
+                                                   />
+                                                   {filterOptions.length > 1 ? (
+                                                     <TableSearchToggle
+                                                       options={filterOptions}
+                                                       value={selectedFilterOption}
+                                                       valueChanged={option => setSelectedFilterOption(option)}
+                                                     />
+                                                   ) : null}
+                                                   <TableSearchToggleHelpText
+                                                     filterOption={selectedFilterOption}
+                                                   />
+                                                 </div>
+                                               : <div />}
         <div>
           {queryCheckBox ?
-            <span
-              style={{
-                display: "flex",
-                alignItems: "center",
-                fontWeight: 500,
-                marginRight: 10,
-              }}
-            >
-              <span style={{marginRight: "8px"}}>{queryCheckBox.text}</span>
-               <Checkbox
-                  checked={queryCheckBoxState}
-                  onChange={()=>{
-                    if (queryCheckBoxState) setQueryCheckBoxState(false);
-                    else setQueryCheckBoxState(true)
-                  }}
-                  size={32}
-                />
-            </span>
+           <span
+             style={{
+               display: "flex",
+               alignItems: "center",
+               fontWeight: 500,
+               marginRight: 10,
+             }}
+           >
+             <span style={{marginRight: "8px"}}>{queryCheckBox.text}</span>
+             <Checkbox
+               checked={queryCheckBoxState}
+               onChange={()=>{
+                 if (queryCheckBoxState) setQueryCheckBoxState(false);
+                 else setQueryCheckBoxState(true)
+               }}
+               size={32}
+             />
+           </span>
           : null}
           {customTableButton ? (
             <button
@@ -315,12 +315,12 @@ const TableStateContainer: React.FC<Props> = ({
             </button>
           ) : null}
           {newItemOnClick ?
-            <button
-              onClick={newItemOnClick}
-              className={buttonStyles.NewButton}
-            >
-              + New Item
-            </button>
+           <button
+             onClick={newItemOnClick}
+             className={buttonStyles.NewButton}
+           >
+             + New Item
+           </button>
           : null}
         </div>
       </div>
@@ -336,7 +336,7 @@ const TableStateContainer: React.FC<Props> = ({
           fontWeight: "var(--font-weight-button)",
         }}
       >
-        <div 
+        <div
           style={{
             paddingTop: "17px",
             paddingBottom: "17px",
@@ -346,32 +346,32 @@ const TableStateContainer: React.FC<Props> = ({
           {`${checkBoxes.length} items selected`}
         </div>
         <div>
-        {
-          checkBoxActions.map((checkboxAction, i) => {
-            const { displayValue, actionFunction, checkIfActionIsApplicable } = checkboxAction;
-            const selectedRows = checkIfActionIsApplicable ? (
-              tableData.filter(row => getIfCheckBoxOfUuidIsSelected(getRowIdentifier(row)) && checkIfActionIsApplicable(row))
-            ) : (
-              tableData.filter(row => getIfCheckBoxOfUuidIsSelected(getRowIdentifier(row)))
-            );
-            return (
-              <button
-                key={i}
-                onClick={() => actionFunction(selectedRows, tableData, setTableData, ()=>fetchWithUrl(currentUrl), ()=>fetchWithUrl(url), setCheckBoxes)}
-                className={styles.TableActionButton}
-              >
-                {`${displayValue} (${selectedRows.length})`}
-              </button>
-            );
-          })
-        }
+          {
+            checkBoxActions.map((checkboxAction, i) => {
+              const { displayValue, actionFunction, checkIfActionIsApplicable } = checkboxAction;
+              const selectedRows = checkIfActionIsApplicable ? (
+                tableData.filter(row => getIfCheckBoxOfUuidIsSelected(getRowIdentifier(row)) && checkIfActionIsApplicable(row))
+              ) : (
+                tableData.filter(row => getIfCheckBoxOfUuidIsSelected(getRowIdentifier(row)))
+              );
+              return (
+                <button
+                  key={i}
+                  onClick={() => actionFunction(selectedRows, tableData, setTableData, ()=>fetchWithUrl(currentUrl), ()=>fetchWithUrl(url), setCheckBoxes)}
+                  className={styles.TableActionButton}
+                >
+                  {`${displayValue} (${selectedRows.length})`}
+                </button>
+              );
+            })
+          }
         </div>
       </div>
       <div style={{flex:1, minHeight: 0}}>
         <Table
-          tableData={dataWithCheckBoxes} 
+          tableData={dataWithCheckBoxes}
           setTableData={setTableData}
-          gridTemplateColumns={gridTemplateColumns} 
+          gridTemplateColumns={gridTemplateColumns}
           columnDefinitions={columnDefinitionsPlusCheckboxSortable}
           dataRetrievalState={dataRetrievalState}
           triggerReloadWithCurrentPage={()=>{fetchWithUrl(currentUrl)}}
@@ -381,11 +381,10 @@ const TableStateContainer: React.FC<Props> = ({
         />
       </div>
       <Pagination
-        page1Url={url}
-        previousUrl={previousUrl}
-        nextUrl={nextUrl}
+        toPage1={() => fetchWithUrl(url)}
+        toNext={nextUrl !== "" ? () => fetchWithUrl(nextUrl) : undefined}
+        toPrevious={previousUrl !== "" ? () => fetchWithUrl(previousUrl) : undefined}
         itemsPerPage={itemsPerPage}
-        reloadFromUrl={fetchWithUrl}
         setItemsPerPage={setItemsPerPage}
       />
     </div>

--- a/src/data_management/labels/LabeltypesTable.tsx
+++ b/src/data_management/labels/LabeltypesTable.tsx
@@ -17,7 +17,7 @@ const navigationUrl = "/data_management/labels/label_types";
 const columnDefinitions = [
   {
     titleRenderFunction: () => "Name",
-    renderFunction: (row: any) => 
+    renderFunction: (row: any) =>
       <span
         className={tableStyles.CellEllipsis}
         title={row.name}
@@ -51,14 +51,14 @@ export const LabeltypesTable = (props:any) =>  {
       explanationText={"Label types are different types of labels that can exist in the system."}
       backUrl={"/data_management/labels"}
     >
-      <TableStateContainer 
-        gridTemplateColumns={"60% 40%"} 
+      <TableStateContainer
+        gridTemplateColumns={"60% 40%"}
         columnDefinitions={columnDefinitions}
-        baseUrl={`${baseUrl}?`} 
+        baseUrl={`${baseUrl}?`}
         checkBoxActions={[]}
         filterOptions={[
-          {value: 'name__icontains=', label: 'Name'},
-          {value: 'uuid=', label: 'UUID'},
+          {value: 'name__icontains', label: 'Name'},
+          {value: 'uuid', label: 'UUID'},
         ]}
       />
     </ExplainSideColumn>

--- a/src/data_management/rasters/RasterLayerTable.tsx
+++ b/src/data_management/rasters/RasterLayerTable.tsx
@@ -35,7 +35,7 @@ export const RasterLayerTable: React.FC<RouteComponentProps> = (props) =>  {
   const columnDefinitions = [
     {
       titleRenderFunction: () => "Name",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={row.name}
@@ -46,7 +46,7 @@ export const RasterLayerTable: React.FC<RouteComponentProps> = (props) =>  {
     },
     {
       titleRenderFunction: () =>  "Based on",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={row.is_geoblock ? 'Geoblock' : 'Raster source'}
@@ -65,7 +65,7 @@ export const RasterLayerTable: React.FC<RouteComponentProps> = (props) =>  {
     },
     {
       titleRenderFunction: () =>  "User",
-      renderFunction: (row: any) =>  
+      renderFunction: (row: any) =>
       <span
         className={tableStyles.CellEllipsis}
         title={row.supplier}
@@ -84,10 +84,10 @@ export const RasterLayerTable: React.FC<RouteComponentProps> = (props) =>  {
       renderFunction: (row: any, tableData:any, setTableData:any, triggerReloadWithCurrentPage:any, triggerReloadWithBasePage:any) => {
         return (
             <TableActionButtons
-              tableRow={row} 
+              tableRow={row}
               tableData={tableData}
-              setTableData={setTableData} 
-              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage} 
+              setTableData={setTableData}
+              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage}
               triggerReloadWithBasePage={triggerReloadWithBasePage}
               editUrl={`${navigationUrlRasters}/${row.uuid}`}
               actions={[
@@ -118,10 +118,10 @@ export const RasterLayerTable: React.FC<RouteComponentProps> = (props) =>  {
       explanationText={defaultRasterLayerHelpTextTable}
       backUrl={"/data_management/rasters"}
     >
-        <TableStateContainer 
-          gridTemplateColumns={"8% 28% 22% 18% 16% 8%"} 
+        <TableStateContainer
+          gridTemplateColumns={"8% 28% 22% 18% 16% 8%"}
           columnDefinitions={columnDefinitions}
-          baseUrl={`${baseUrl}?`} 
+          baseUrl={`${baseUrl}?`}
           checkBoxActions={[
             {
               displayValue: "Delete",
@@ -132,10 +132,10 @@ export const RasterLayerTable: React.FC<RouteComponentProps> = (props) =>  {
           ]}
           newItemOnClick={handleNewRasterClick}
           filterOptions={[
-            {value: 'name__icontains=', label: 'Name'},
-            {value: 'uuid=', label: 'UUID'},
+            {value: 'name__icontains', label: 'Name'},
+            {value: 'uuid', label: 'UUID'},
           ]}
-          defaultUrlParams={'&scenario__isnull=true'} // to exclude 3Di scenario rasters
+          defaultUrlParams={{scenario__isnull: 'true'}} // to exclude 3Di scenario rasters
         />
         {rowsToBeDeleted.length > 0 ? (
           <DeleteModal

--- a/src/data_management/rasters/RasterSourceTable.tsx
+++ b/src/data_management/rasters/RasterSourceTable.tsx
@@ -27,7 +27,7 @@ export const RasterSourceTable = (props:any) =>  {
   const [showDeleteFailedModal, setShowDeleteFailedModal] = useState<boolean>(false);
   const rastersTotalSize = useSelector(getScenarioTotalSize);
 
-  useEffect(() => { 
+  useEffect(() => {
     if (rowToBeDeleted) {
       fetch(baseUrl + rowToBeDeleted.uuid)
         .then((result:any)=>{
@@ -108,7 +108,7 @@ export const RasterSourceTable = (props:any) =>  {
   const rasterSourceColumnDefinitions = [
     {
       titleRenderFunction: () => "Name",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={row.name}
@@ -132,7 +132,7 @@ export const RasterSourceTable = (props:any) =>  {
     },
     {
       titleRenderFunction: () =>  "Temporal",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
         >
@@ -143,7 +143,7 @@ export const RasterSourceTable = (props:any) =>  {
     },
     {
       titleRenderFunction: () =>  "Size",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={`${row.size? row.size: 0} Bytes`}
@@ -158,10 +158,10 @@ export const RasterSourceTable = (props:any) =>  {
       renderFunction: (row: any, tableData:any, setTableData:any, triggerReloadWithCurrentPage:any, triggerReloadWithBasePage:any) => {
         return (
             <TableActionButtons
-              tableRow={row} 
+              tableRow={row}
               tableData={tableData}
-              setTableData={setTableData} 
-              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage} 
+              setTableData={setTableData}
+              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage}
               triggerReloadWithBasePage={triggerReloadWithBasePage}
               editUrl={`${navigationUrlRasters}/${row.uuid}`}
               actions={[
@@ -202,15 +202,15 @@ export const RasterSourceTable = (props:any) =>  {
       imgUrl={rasterSourcesIcon}
       imgAltDescription={"Raster-Source icon"}
       headerText={"Raster Sources"}
-      explanationText={defaultRasterSourceExplanationTextTable(bytesToDisplayValue(rastersTotalSize))} 
+      explanationText={defaultRasterSourceExplanationTextTable(bytesToDisplayValue(rastersTotalSize))}
       backUrl={"/data_management/rasters"}
     >
-      <TableStateContainer 
+      <TableStateContainer
         // with checkboxes
         // gridTemplateColumns={"8% 29% 25% 10% 20% 8%"}
-        gridTemplateColumns={"37% 25% 10% 20% 8%"}  
+        gridTemplateColumns={"37% 25% 10% 20% 8%"}
         columnDefinitions={rasterSourceColumnDefinitions}
-        baseUrl={`${baseUrl}?`} 
+        baseUrl={`${baseUrl}?`}
         checkBoxActions={[
           // implement later
           // {
@@ -224,10 +224,10 @@ export const RasterSourceTable = (props:any) =>  {
         ]}
         newItemOnClick={handleNewRasterClick}
         filterOptions={[
-          {value: 'name__icontains=', label: 'Name'},
-          {value: 'uuid=', label: 'UUID'},
+          {value: 'name__icontains', label: 'Name'},
+          {value: 'uuid', label: 'UUID'},
         ]}
-        defaultUrlParams={'&scenario__isnull=true'} // to exclude 3Di scenario rasters
+        defaultUrlParams={{scenario__isnull: 'true'}} // to exclude 3Di scenario rasters
       />
       {
         rowToBeDeleted && !currentRowDetailView ?
@@ -249,7 +249,7 @@ export const RasterSourceTable = (props:any) =>  {
         // false &&
         currentRowDetailView && (currentRowDetailView.layers.length !== 0 || currentRowDetailView.labeltypes.length !== 0) ?
 
-        <DeleteRasterSourceNotAllowed 
+        <DeleteRasterSourceNotAllowed
           closeDialogAction={()=>{
             setRowToBeDeleted(null);
             setCurrentRowDetailView(null);
@@ -261,10 +261,10 @@ export const RasterSourceTable = (props:any) =>  {
         :
         null
       }
-      { 
-        currentRowDetailView && deleteFunction 
-        && 
-        (currentRowDetailView.layers.length === 0 && currentRowDetailView.labeltypes.length === 0) 
+      {
+        currentRowDetailView && deleteFunction
+        &&
+        (currentRowDetailView.layers.length === 0 && currentRowDetailView.labeltypes.length === 0)
         ?
            <Modal
            title={'Are you sure?'}
@@ -279,9 +279,9 @@ export const RasterSourceTable = (props:any) =>  {
                 setCurrentRowDetailView(null);
                 setDeleteFunction(null);
               }
-              
+
              });
-             
+
            }}
            cancelAction={()=>{
              setRowToBeDeleted(null);
@@ -291,12 +291,12 @@ export const RasterSourceTable = (props:any) =>  {
            disableButtons={busyDeleting}
          >
            <p>Are you sure? You are deleting the following raster-source:</p>
-           {ModalDeleteContent([currentRowDetailView], busyDeleting, [{name: "name", width: 65}, {name: "uuid", width: 25}])}             
+           {ModalDeleteContent([currentRowDetailView], busyDeleting, [{name: "name", width: 65}, {name: "uuid", width: 25}])}
          </Modal>
         :
           null
         }
-        { 
+        {
         currentRowDetailView &&  showDeleteFailedModal?
            <Modal
            title={'Not allowed'}
@@ -309,18 +309,18 @@ export const RasterSourceTable = (props:any) =>  {
            <p>You are trying to delete the following raster-source:</p>
            {ModalDeleteContent([currentRowDetailView], busyDeleting, [{name: "name", width: 65}, {name: "uuid", width: 25}])}
            <p>But this raster-source is still in use by objects outside your organisation.</p>
-           <p>{"Please contact "} 
+           <p>{"Please contact "}
              <a
               href="https://nelen-schuurmans.topdesk.net/tas/public/ssp"
               target="_blank"
               rel="noopener noreferrer"
             >support</a>
-          </p>             
+          </p>
          </Modal>
         :
           null
         }
-        {/* { 
+        {/* {
         rowsToBeDeleted.length > 0?
            <Modal
            title={'Are you sure?'}
@@ -337,11 +337,11 @@ export const RasterSourceTable = (props:any) =>  {
           }}
           disableButtons={busyDeleting}
          >
-           
+
            <p>Are you sure? You are deleting the following raster-sources:</p>
-           
+
            {ModalDeleteContent(rowsToBeDeleted, busyDeleting, [{name: "name", width: 65}, {name: "uuid", width: 25}])}
-           
+
          </Modal>
         :
           null

--- a/src/data_management/scenarios/ScenarioTable.tsx
+++ b/src/data_management/scenarios/ScenarioTable.tsx
@@ -70,7 +70,7 @@ export const ScenarioTable = () =>  {
   const columnDefinitions = [
     {
       titleRenderFunction: () => "Name",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={row.name}
@@ -86,7 +86,7 @@ export const ScenarioTable = () =>  {
     },
     {
       titleRenderFunction: () =>  "Based on",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={row.model_name}
@@ -102,7 +102,7 @@ export const ScenarioTable = () =>  {
     },
     {
       titleRenderFunction: () =>  "User",
-      renderFunction: (row: any) =>  
+      renderFunction: (row: any) =>
       <span
         className={tableStyles.CellEllipsis}
         title={row.username}
@@ -118,7 +118,7 @@ export const ScenarioTable = () =>  {
     },
     {
       titleRenderFunction: () =>  "Size",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={`${row.total_size? row.total_size: 0} Bytes`}
@@ -133,10 +133,10 @@ export const ScenarioTable = () =>  {
       renderFunction: (row: any, tableData:any, setTableData:any, triggerReloadWithCurrentPage:any, triggerReloadWithBasePage:any) => {
         return (
             <TableActionButtons
-              tableRow={row} 
+              tableRow={row}
               tableData={tableData}
-              setTableData={setTableData} 
-              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage} 
+              setTableData={setTableData}
+              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage}
               triggerReloadWithBasePage={triggerReloadWithBasePage}
               editUrl={`${navigationUrl}/${row.uuid}`}
               actions={row.has_raw_results ? [
@@ -175,10 +175,10 @@ export const ScenarioTable = () =>  {
       explanationText={defaultScenarioExplanationText(bytesToDisplayValue(scenarioTotalSize), selectedOrganisation.name)}
       backUrl={"/data_management"}
     >
-        <TableStateContainer 
+        <TableStateContainer
           gridTemplateColumns={"4fr 28fr 29fr 15fr 10fr 10fr 4fr"}
           columnDefinitions={columnDefinitions}
-          baseUrl={`${baseUrl}?`} 
+          baseUrl={`${baseUrl}?`}
           checkBoxActions={[
             {
               displayValue: "Change rights",
@@ -205,13 +205,13 @@ export const ScenarioTable = () =>  {
           ]}
           queryCheckBox={{
             text:"Only show own scenario's",
-            adaptUrlFunction: (url:string) => {return userName? url + `&username__contains=${userName}` : url},
+            extraParamsWhenChecked: {username__contains: userName},
           }}
           filterOptions={[
-            {value: 'name__icontains=', label: 'Name'},
-            {value: 'uuid=', label: 'UUID'},
-            {value: 'username__icontains=', label: 'Username'},
-            {value: 'model_name__icontains=', label: 'Model name'},
+            {value: 'name__icontains', label: 'Name'},
+            {value: 'uuid', label: 'UUID'},
+            {value: 'username__icontains', label: 'Username'},
+            {value: 'model_name__icontains', label: 'Model name'},
           ]}
         />
         {rowsToBeDeleted.length > 0 ? (

--- a/src/data_management/timeseries/locations/LocationsTable.tsx
+++ b/src/data_management/timeseries/locations/LocationsTable.tsx
@@ -54,7 +54,7 @@ export const LocationsTable = (props: RouteComponentProps) =>  {
   const columnDefinitions = [
     {
       titleRenderFunction: () => "Name",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={row.name}
@@ -66,7 +66,7 @@ export const LocationsTable = (props: RouteComponentProps) =>  {
     },
     {
       titleRenderFunction: () => "Code",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={row.code}
@@ -78,7 +78,7 @@ export const LocationsTable = (props: RouteComponentProps) =>  {
     },
     {
       titleRenderFunction: () => "Accessibility",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={row.access_modifier}
@@ -93,10 +93,10 @@ export const LocationsTable = (props: RouteComponentProps) =>  {
       renderFunction: (row: any, tableData:any, setTableData:any, triggerReloadWithCurrentPage:any, triggerReloadWithBasePage:any) => {
         return (
             <TableActionButtons
-              tableRow={row} 
+              tableRow={row}
               tableData={tableData}
-              setTableData={setTableData} 
-              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage} 
+              setTableData={setTableData}
+              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage}
               triggerReloadWithBasePage={triggerReloadWithBasePage}
               editUrl={`${navigationUrl}/${row.uuid}`}
               actions={[
@@ -131,10 +131,10 @@ export const LocationsTable = (props: RouteComponentProps) =>  {
       explanationText={defaultTableHelpText('Search or sort your locations here.')}
       backUrl={"/data_management/timeseries"}
     >
-      <TableStateContainer 
-        gridTemplateColumns={"4fr 36fr 36fr 16fr 8fr"} 
+      <TableStateContainer
+        gridTemplateColumns={"4fr 36fr 36fr 16fr 8fr"}
         columnDefinitions={columnDefinitions}
-        baseUrl={`${baseUrl}?`} 
+        baseUrl={`${baseUrl}?`}
         checkBoxActions={[
           {
             displayValue: "Change rights",
@@ -149,8 +149,8 @@ export const LocationsTable = (props: RouteComponentProps) =>  {
         ]}
         newItemOnClick={handleNewClick}
         filterOptions={[
-          {value: 'name__startswith=', label: 'Name *'},
-          {value: 'code__startswith=', label: 'Code *'},
+          {value: 'name__startswith', label: 'Name *'},
+          {value: 'code__startswith', label: 'Code *'},
         ]}
       />
       {rowToBeDeleted && !dependentTimeseries ? (

--- a/src/data_management/timeseries/monitoring_networks/MonitoringNetworksTable.tsx
+++ b/src/data_management/timeseries/monitoring_networks/MonitoringNetworksTable.tsx
@@ -36,7 +36,7 @@ export const MonitoringNetworksTable = (props: RouteComponentProps) =>  {
   const columnDefinitions = [
     {
       titleRenderFunction: () => "Name",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={row.name}
@@ -63,10 +63,10 @@ export const MonitoringNetworksTable = (props: RouteComponentProps) =>  {
       renderFunction: (row: any, tableData:any, setTableData:any, triggerReloadWithCurrentPage:any, triggerReloadWithBasePage:any) => {
         return (
             <TableActionButtons
-              tableRow={row} 
+              tableRow={row}
               tableData={tableData}
-              setTableData={setTableData} 
-              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage} 
+              setTableData={setTableData}
+              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage}
               triggerReloadWithBasePage={triggerReloadWithBasePage}
               editUrl={`${navigationUrl}/${row.uuid}`}
               actions={[
@@ -125,7 +125,7 @@ export const MonitoringNetworksTable = (props: RouteComponentProps) =>  {
           }
         ]}
         filterOptions={[
-          {value: 'name__icontains=', label: 'Name'},
+          {value: 'name__icontains', label: 'Name'},
         ]}
       />
       {rowsToBeDeleted.length > 0 ? (

--- a/src/data_management/timeseries/monitoring_networks/TimeseriesModal.tsx
+++ b/src/data_management/timeseries/monitoring_networks/TimeseriesModal.tsx
@@ -199,11 +199,10 @@ function TimeseriesModal (props: MyProps & DispatchProps) {
               </div>
             </div>
             <Pagination
-              page1Url={baseUrl + `?page_size=${itemsPerPage}`}
-              previousUrl={timeseriesApiResponse.previous}
-              nextUrl={timeseriesApiResponse.next}
+              toPage1={() => setCurrentUrl(baseUrl + `?page_size=${itemsPerPage}`)}
+              toNext={timeseriesApiResponse.next ? () => setCurrentUrl(timeseriesApiResponse.next) : undefined}
+              toPrevious={timeseriesApiResponse.previous ? () => setCurrentUrl(timeseriesApiResponse.previous) : undefined}
               itemsPerPage={itemsPerPage}
-              reloadFromUrl={setCurrentUrl}
               setItemsPerPage={setItemsPerPage}
             />
           </div>

--- a/src/data_management/timeseries/monitoring_networks/TimeseriesModal.tsx
+++ b/src/data_management/timeseries/monitoring_networks/TimeseriesModal.tsx
@@ -35,9 +35,9 @@ function TimeseriesModal (props: MyProps & DispatchProps) {
 
   // Filter options for timeseries list
   const filterOptions = [
-    {value: 'name__startswith=', label: 'Name *'},
-    {value: 'location__name__startswith=', label: 'Location name *'},
-    {value: 'location__code__startswith=', label: 'Location code *'},
+    {value: 'name__startswith', label: 'Name *'},
+    {value: 'location__name__startswith', label: 'Location name *'},
+    {value: 'location__code__startswith', label: 'Location code *'},
   ];
 
   const [timeseriesApiResponse, setTimeseriesApiResponse] = useState<APIResponse>({

--- a/src/data_management/timeseries/timeseries/TimeseriesTable.tsx
+++ b/src/data_management/timeseries/timeseries/TimeseriesTable.tsx
@@ -40,7 +40,7 @@ export const TimeseriesTable = (props: RouteComponentProps) =>  {
   const columnDefinitions = [
     {
       titleRenderFunction: () => "Name",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={`${row.name} - UUID: ${row.uuid}`}
@@ -68,7 +68,7 @@ export const TimeseriesTable = (props: RouteComponentProps) =>  {
     },
     {
       titleRenderFunction: () => "Observation type",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={
@@ -78,8 +78,8 @@ export const TimeseriesTable = (props: RouteComponentProps) =>  {
           }
         >
           {!row.observation_type? "" :
-            row.observation_type.unit? <>{row.observation_type.code}{" "} <span style={{fontWeight:600,}}>{`(${row.observation_type.unit})`}</span></> : 
-            row.observation_type.code 
+            row.observation_type.unit? <>{row.observation_type.code}{" "} <span style={{fontWeight:600,}}>{`(${row.observation_type.unit})`}</span></> :
+            row.observation_type.code
           }
         </span>
       ,
@@ -87,7 +87,7 @@ export const TimeseriesTable = (props: RouteComponentProps) =>  {
     },
     {
       titleRenderFunction: () => "Location",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           style={{
@@ -111,7 +111,7 @@ export const TimeseriesTable = (props: RouteComponentProps) =>  {
     },
     {
       titleRenderFunction: () => "Accessibility",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={row.access_modifier}
@@ -126,10 +126,10 @@ export const TimeseriesTable = (props: RouteComponentProps) =>  {
       renderFunction: (row: any, tableData:any, setTableData:any, triggerReloadWithCurrentPage:any, triggerReloadWithBasePage:any) => {
         return (
             <TableActionButtons
-              tableRow={row} 
+              tableRow={row}
               tableData={tableData}
-              setTableData={setTableData} 
-              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage} 
+              setTableData={setTableData}
+              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage}
               triggerReloadWithBasePage={triggerReloadWithBasePage}
               editUrl={`${navigationUrl}/${row.uuid}`}
               actions={[
@@ -202,9 +202,9 @@ export const TimeseriesTable = (props: RouteComponentProps) =>  {
           }
         ]}
         filterOptions={[
-          {value: 'name__startswith=', label: 'Name *'},
-          {value: 'location__name__startswith=', label: 'Location name *'},
-          {value: 'location__code__startswith=', label: 'Location code *'},
+          {value: 'name__startswith', label: 'Name *'},
+          {value: 'location__name__startswith', label: 'Location name *'},
+          {value: 'location__code__startswith', label: 'Location code *'},
         ]}
       />
       {rowsToBeDeleted.length > 0 ? (

--- a/src/data_management/wms_layers/WmsLayerTable.tsx
+++ b/src/data_management/wms_layers/WmsLayerTable.tsx
@@ -30,7 +30,7 @@ export const WmsLayerTable = (props: RouteComponentProps) =>  {
   const columnDefinitions = [
     {
       titleRenderFunction: () => "Name",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={row.name}
@@ -41,7 +41,7 @@ export const WmsLayerTable = (props: RouteComponentProps) =>  {
     },
     {
       titleRenderFunction: () =>  "Description",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={row.description}
@@ -55,10 +55,10 @@ export const WmsLayerTable = (props: RouteComponentProps) =>  {
       renderFunction: (row: any, tableData:any, setTableData:any, triggerReloadWithCurrentPage:any, triggerReloadWithBasePage:any) => {
         return (
             <TableActionButtons
-              tableRow={row} 
+              tableRow={row}
               tableData={tableData}
-              setTableData={setTableData} 
-              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage} 
+              setTableData={setTableData}
+              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage}
               triggerReloadWithBasePage={triggerReloadWithBasePage}
               editUrl={`${navigationUrl}/${row.uuid}`}
               actions={[
@@ -88,13 +88,13 @@ export const WmsLayerTable = (props: RouteComponentProps) =>  {
       imgUrl={wmsIcon}
       imgAltDescription={"WMS-Layer icon"}
       headerText={"WMS Layers"}
-      explanationText={"WMS-Layers allow to configure layers in lizard even if they are hosted on another platform"} 
+      explanationText={"WMS-Layers allow to configure layers in lizard even if they are hosted on another platform"}
       backUrl={"/data_management"}
     >
-        <TableStateContainer 
-          gridTemplateColumns={"8% 29% 55% 8%"} 
+        <TableStateContainer
+          gridTemplateColumns={"8% 29% 55% 8%"}
           columnDefinitions={columnDefinitions}
-          baseUrl={`${baseUrl}?`} 
+          baseUrl={`${baseUrl}?`}
           checkBoxActions={[
             {
               displayValue: "Delete",
@@ -105,10 +105,10 @@ export const WmsLayerTable = (props: RouteComponentProps) =>  {
           ]}
           newItemOnClick={handleNewRasterClick}
           filterOptions={[
-            {value: 'name__icontains=', label: 'Name'},
+            {value: 'name__icontains', label: 'Name'},
             // not needed for now
             // {value: 'datasets__slug__icontains=', label: 'Datasets slug'},
-            {value: 'uuid=', label: 'UUID'},
+            {value: 'uuid', label: 'UUID'},
           ]}
         />
         {rowsToBeDeleted.length > 0 ? (

--- a/src/users/UserTable.tsx
+++ b/src/users/UserTable.tsx
@@ -51,7 +51,7 @@ export const UserTable = (props: RouteComponentProps) =>  {
   const columnDefinitions = [
     {
       titleRenderFunction: () => "Username",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={row.username}
@@ -63,7 +63,7 @@ export const UserTable = (props: RouteComponentProps) =>  {
     },
     {
       titleRenderFunction: () => "Email",
-      renderFunction: (row: any) => 
+      renderFunction: (row: any) =>
         <span
           className={tableStyles.CellEllipsis}
           title={row.email}
@@ -92,10 +92,10 @@ export const UserTable = (props: RouteComponentProps) =>  {
       renderFunction: (row: any, tableData:any, setTableData:any, triggerReloadWithCurrentPage:any, triggerReloadWithBasePage:any) => {
         return (
             <TableActionButtons
-              tableRow={row} 
+              tableRow={row}
               tableData={tableData}
-              setTableData={setTableData} 
-              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage} 
+              setTableData={setTableData}
+              triggerReloadWithCurrentPage={triggerReloadWithCurrentPage}
               triggerReloadWithBasePage={triggerReloadWithBasePage}
               editUrl={`${navigationUrl}/${row.id}`}
               actions={[
@@ -139,19 +139,19 @@ export const UserTable = (props: RouteComponentProps) =>  {
         }}
         filterOptions={[
           {
-            value: 'username__icontains=',
+            value: 'username__icontains',
             label: 'Username'
           },
           {
-            value: 'first_name__icontains=',
+            value: 'first_name__icontains',
             label: 'First name'
           },
           {
-            value: 'last_name__icontains=',
+            value: 'last_name__icontains',
             label: 'Last name'
           },
           {
-            value: 'email__icontains=',
+            value: 'email__icontains',
             label: 'Email'
           }
         ]}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,6 +1205,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.6.2":
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.12.7", "@babel/template@^7.3.3":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.7.tgz#c817233696018e39fbb6c491d2fb684e05ed43bc"
@@ -4767,6 +4774,11 @@ bfj@^7.0.2:
     hoopy "^0.1.4"
     tryer "^1.0.1"
 
+big-integer@^1.6.16:
+  version "1.6.48"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
+  integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -4909,6 +4921,20 @@ braces@^3.0.1, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
+  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.1.0"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    oblivious-set "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 brorand@^1.0.1:
   version "1.1.0"
@@ -6705,6 +6731,11 @@ detect-node@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
   integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
+
+detect-node@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
+  integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
 detect-port-alt@1.1.6:
   version "1.1.6"
@@ -10522,6 +10553,11 @@ jest@26.6.0:
     import-local "^3.0.2"
     jest-cli "^26.6.0"
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 js-string-escape@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/js-string-escape/-/js-string-escape-1.0.1.tgz#e2625badbc0d67c7533e9edc1068c587ae4137ef"
@@ -11155,6 +11191,14 @@ markdown-to-jsx@^6.11.4:
     prop-types "^15.6.2"
     unquote "^1.1.0"
 
+match-sorter@^6.0.2:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.0.tgz#454a1b31ed218cddbce6231a0ecb5fdc549fed01"
+  integrity sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 material-colors@^1.2.1:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.6.tgz#6d1958871126992ceecc72f4bcc4d8f010865f46"
@@ -11330,6 +11374,11 @@ micromatch@^4.0.2:
   dependencies:
     braces "^3.0.1"
     picomatch "^2.0.5"
+
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -11613,6 +11662,13 @@ nan@^2.12.1:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoid@^3.1.20:
   version "3.1.20"
@@ -11956,6 +12012,11 @@ objectorarray@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/objectorarray/-/objectorarray-1.0.4.tgz#d69b2f0ff7dc2701903d308bb85882f4ddb49483"
   integrity sha512-91k8bjcldstRz1bG6zJo8lWD7c6QXcB4nTDUqiEvIL1xAsLoZlOOZZG+nd6YPz+V7zY1580J4Xxh1vZtyv4i/w==
+
+oblivious-set@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
+  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
@@ -14001,6 +14062,15 @@ react-popper@^2.2.4:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
+react-query@^3.17.2:
+  version "3.17.2"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.17.2.tgz#3ed5b0460a5a05332fbb175c36da55fb2d3ff929"
+  integrity sha512-icMtYL/+jUv0Q3n8GRz6CTyMYKh+l5EBKwhkr8qhbtYRORr43YGiN6EJSyw9WFaSQ9bwD1G9ZhaFxow9NMV0Sw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
+
 react-redux@^7.0.2:
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.2.tgz#03862e803a30b6b9ef8582dadcc810947f74b736"
@@ -14568,6 +14638,11 @@ remark-squeeze-paragraphs@4.0.0:
   dependencies:
     mdast-squeeze-paragraphs "^4.0.0"
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -14815,17 +14890,17 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.0, rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -16583,6 +16658,14 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
mportant changes are in TableStateContainer, and in api/hooks.ts. Rest is keeping things working and my editor changing spaces.

- Use React Query for the queries of TableStateContainer

- It also handles pagination, because it has to know about using previous / next URLs from the response, if any

- Can also use setPage() pagination

- Can use custom fetch functions (e.g. more 3Di specific, OpenAPI functions) optionally; if the return value doesn't have 'next' and 'previous'  URLs, then those functions don't work and setPage() does.

- To make that possible, URL params are combined with the baseUrl as late as possible, everything is based on keeping a "Params" Record as long as possible (so that alternative fetch functions can also pass the contents to open api generated functions if they want, also because it looks cleaner anyway)
- 
- Kept checkboxes and filtering out of this hook for now, maybe put it in a different hook?

- Moved knowledge of URLs out of Pagination component, it only gets functions
